### PR TITLE
Remove bad DNS servers

### DIFF
--- a/resolver-list.yml
+++ b/resolver-list.yml
@@ -1,9022 +1,8992 @@
 #This is a list of all the open DNS resolvers dnsyo uses
 #Feel free to add more, but please include the reverse DNS
 #country code and providers netblock name
-  - 
+  -
     ip: "152.160.81.10"
     provider: "123NET - 123.Net, Inc."
     reverse: "unknown.static.123.net"
     country: "US"
-  - 
+  -
     ip: "208.72.120.204"
     provider: "295CA-TOR-ASN - FIBERNETICS CORPORATION"
     reverse: "dns1.295.ca"
     country: "CA"
-  - 
+  -
     ip: "208.79.56.204"
     provider: "295CA-TOR-ASN - FIBERNETICS CORPORATION"
     reverse: "dns2.295.ca"
     country: "CA"
-  - 
+  -
     ip: "204.194.232.200"
     provider: "302-DIRECT-MEDIA-ASN - 302 Direct Media LLC"
     reverse: "204.194.232.200"
     country: "US"
-  - 
+  -
     ip: "204.194.234.200"
     country: "US"
     reverse: "204.194.234.200"
     provider: "302-DIRECT-MEDIA-ASN - 302 Direct Media LLC"
-  - 
+  -
     ip: "193.227.232.2"
     provider: "AARI State Institution Arctic and Antarctic Research Institute"
     reverse: "e0.star.aari.ru"
     country: "RU"
-  - 
+  -
     ip: "213.172.33.34"
     country: "ES"
     reverse: "ns1.neo.es"
     provider: "ABRARED NEO-SKY 2002 Autonomous System 1"
-  - 
+  -
     ip: "213.172.33.35"
     provider: "ABRARED NEO-SKY 2002 Autonomous System 1"
     reverse: "ns2.neo.es"
     country: "ES"
-  - 
+  -
     ip: "84.237.96.2"
     country: "RU"
     reverse: "ns.ac-tel.ru"
     provider: "ACADEMTELECOM-AS West Siberian Regional AcademTelecom Networks"
-  - 
+  -
     ip: "217.26.177.2"
     country: "RU"
     reverse: "217.26.177.2"
     provider: "ACB-AS Open Joint-Stock Company _Capital Merchant Bank_"
-  - 
+  -
     ip: "82.211.8.90"
     country: "DE"
     reverse: "server2.alexanderb.info"
     provider: "ACCELERATED-IT Accelerated IT Services GmbH"
-  - 
+  -
     ip: "194.187.164.20"
     provider: "ACCELERATED-IT Accelerated IT Services GmbH"
     reverse: "ns1.accelerated.de"
     country: "DE"
-  - 
+  -
     ip: "212.66.128.129"
     provider: "ACCOM NetAachen GmbH"
     reverse: "arc02.accom.a1-net.de"
     country: "DE"
-  - 
+  -
     ip: "212.66.129.98"
     country: "DE"
     reverse: "dns.a1-net.de"
     provider: "ACCOM NetAachen GmbH"
-  - 
+  -
     ip: "212.14.41.6"
     provider: "ACI-EDU-AS Zachodniopomorski Uniwersytet Technologiczny w Szczecinie, Akademickie Centrum Informatyki"
     reverse: "bork.ksiaznica.szczecin.pl"
     country: "PL"
-  - 
+  -
     ip: "8.5.244.5"
     country: "US"
     reverse: "dns01.sjc01.acndigital.net"
     provider: "ACN-DIGITAL-PHONE - ACN"
-  - 
+  -
     ip: "8.15.12.5"
     provider: "ACN-DIGITAL-PHONE - ACN"
     reverse: "dns01.iad01.acndigital.net"
     country: "US"
-  - 
+  -
     ip: "204.101.45.5"
     provider: "ACN-DIGITAL-PHONE - ACN"
     reverse: "204.101.45.5"
     country: "US"
-  - 
+  -
     ip: "195.219.75.100"
     provider: "ACOTELSA-AS Acitivdades de consultoria y Telecomunicaciones SA"
     reverse: "dns1.acotelsa.com"
     country: "ES"
-  - 
+  -
     ip: "195.219.75.101"
     country: "ES"
     reverse: "dns2.acotelsa.com"
     provider: "ACOTELSA-AS Acitivdades de consultoria y Telecomunicaciones SA"
-  - 
+  -
     ip: "153.122.0.30"
     country: "JP"
     reverse: "bd.ptr42.public.gmocloud.com"
     provider: "ACROSS Dream Wave Shizuoka Co. Ltd."
-  - 
+  -
     ip: "218.223.68.1"
     country: "JP"
     reverse: "ns1.across.or.jp"
     provider: "ACROSS Dream Wave Shizuoka Co. Ltd."
-  - 
+  -
     ip: "218.223.68.33"
     provider: "ACROSS Dream Wave Shizuoka Co. Ltd."
     reverse: "ns2.across.or.jp"
     country: "JP"
-  - 
+  -
     ip: "24.154.1.5"
     provider: "ACS-INTERNET - Armstrong Cable Services"
     reverse: "ns2.zbzoom.net"
     country: "US"
-  - 
+  -
     ip: "213.159.193.54"
     country: "RU"
     reverse: "ns.i365.ru"
     provider: "ACSIT _Internet & Telephone Company_ private joint stock company (ITC)"
-  - 
+  -
     ip: "62.140.218.148"
     country: "GB"
     reverse: "ns2.mnet.net.uk"
     provider: "ADAPT-AS Adapt Services Ltd"
-  - 
+  -
     ip: "85.133.52.27"
     country: "GB"
     reverse: "ns2.glitchhosting.com"
     provider: "ADAPT-AS Adapt Services Ltd"
-  - 
+  -
     ip: "64.136.164.77"
     provider: "ADBASE - Ad-base Systems, Inc."
     reverse: "node77.164.136.64.1dial.com"
     country: "US"
-  - 
+  -
     ip: "64.136.173.5"
     country: "US"
     reverse: "node5.173.136.64.1dial.com"
     provider: "ADBASE - Ad-base Systems, Inc."
-  - 
+  -
     ip: "212.51.16.1"
     country: "DE"
     reverse: "ns1.addix.de"
     provider: "ADDIX-AS ADDIX Internet Services GmbH"
-  - 
+  -
     ip: "212.51.17.1"
     provider: "ADDIX-AS ADDIX Internet Services GmbH"
     reverse: "ns2.addix.de"
     country: "DE"
-  - 
+  -
     ip: "91.194.96.5"
     provider: "ADELINOVIUS SARL Adeli"
     reverse: "ns5n.adeliwifi.info"
     country: "FR"
-  - 
+  -
     ip: "79.175.167.140"
     provider: "AFRANET AFRANET Co. Tehran, Iran"
     reverse: "ns1.netrise.ir"
     country: "IR"
-  - 
+  -
     ip: "212.233.88.2"
     provider: "AGTELECOM-AS _AMT GROUP TELECOM_ Limited Liability Company"
     reverse: "ns2.agtel.net"
     country: "RU"
-  - 
+  -
     ip: "207.130.95.40"
     country: "US"
     reverse: "border2.honda.com"
     provider: "AHM-CORP - American Honda Motor Corporation"
-  - 
+  -
     ip: "205.134.162.209"
     provider: "AIN - American Information Network"
     reverse: "dns6.ai.net"
     country: "US"
-  - 
+  -
     ip: "195.137.208.66"
     country: "PL"
     reverse: "ryba.aiut.com.pl"
     provider: "AIUT-AS Aiut Sp. z o.o."
-  - 
+  -
     ip: "81.24.32.134"
     provider: "AIXTRANET-AS Aixtranet"
     reverse: "ns1.aixtra.net"
     country: "DE"
-  - 
+  -
     ip: "80.250.85.4"
     country: "RU"
     reverse: "alpha.vimcom.ru"
     provider: "ALFA-LTD-AS Alfa Ltd."
-  - 
+  -
     ip: "94.103.233.62"
     country: "RU"
     reverse: "ntp.a-n-t.ru"
     provider: "ALFANETTELECOM-AS Ltd _Alfa Net Telecom_"
-  - 
+  -
     ip: "91.194.178.5"
     provider: "ALIONIS Alionis"
     reverse: "gon.avencall.com"
     country: "FR"
-  - 
+  -
     ip: "194.116.142.1"
     country: "FR"
     reverse: "gw-sofialys.alionet.net"
     provider: "ALIONIS Alionis"
-  - 
+  -
     ip: "193.42.153.6"
     country: "PL"
     reverse: "dns1.alstor.com.pl"
     provider: "ALSTOR-AS ALSTOR T. Szukala i Wspolnicy Sp.j."
-  - 
+  -
     ip: "208.78.24.238"
     country: "US"
     reverse: "dns1.nyc.dns-roots.net"
     provider: "AMC - Atlantic Metro Communications"
-  - 
+  -
     ip: "213.143.33.8"
     provider: "AMENA-AS France Telecom Espana SA"
     reverse: "dns.amenate.com"
     country: "ES"
-  - 
+  -
     ip: "69.60.160.203"
     provider: "AMERICA - Access America"
     reverse: "edelta2.dadns.america.net"
     country: "US"
-  - 
+  -
     ip: "91.193.144.114"
     country: "PL"
     reverse: "dns.amg.net.pl"
     provider: "AMGNET AMG.net SA"
-  - 
+  -
     ip: "91.214.96.10"
     country: "RU"
     reverse: "ns1.sokratel.net"
     provider: "AMT closed joint-stock company"
-  - 
+  -
     ip: "213.183.56.33"
     provider: "ANDERS-AS Anders Telecom Ltd."
     reverse: "ru.godau.eu"
     country: "RU"
-  - 
+  -
     ip: "24.89.0.21"
     country: "US"
     reverse: "ns4.myactv.net"
     provider: "ANTIETAM - Antietam Cable Television, Inc"
-  - 
+  -
     ip: "164.2.255.241"
     country: "FR"
     reverse: "gw-aphp.ap-hop-paris.fr"
     provider: "APHP-AS Assistance Publique-Hopitaux de Paris"
-  - 
+  -
     ip: "63.238.52.1"
     provider: "API-DIGITAL - API Digital Communications Group, LLC"
     reverse: "ns1.api-digital.com"
     country: "US"
-  - 
+  -
     ip: "63.238.52.2"
     country: "US"
     reverse: "ns2.api-digital.com"
     provider: "API-DIGITAL - API Digital Communications Group, LLC"
-  - 
+  -
     ip: "66.112.235.200"
     country: "US"
     reverse: "ns4.apogeenet.net"
     provider: "APOGEE-TELECOM - Apogee Telecom Inc."
-  - 
+  -
     ip: "194.24.238.18"
     provider: "AQUANET-PL Aquanet S.A."
     reverse: "sol.aquanet.pl"
     country: "PL"
-  - 
+  -
     ip: "209.168.126.3"
     provider: "ARGIA - ARGIA"
     reverse: "ns5.argia.net"
     country: "US"
-  - 
+  -
     ip: "217.140.98.25"
     country: "GB"
     reverse: "ns4.arm.com"
     provider: "ARM-AS ARM Ltd"
-  - 
+  -
     ip: "217.140.108.113"
     provider: "ARM-AS ARM Ltd"
     reverse: "217.140.108.113"
     country: "GB"
-  - 
+  -
     ip: "81.200.144.3"
     provider: "ARTEM-CATV-AS JSC Artemovskoye Interaktivnoe Televidenie"
     reverse: "serv0.artem-catv.ru"
     country: "RU"
-  - 
+  -
     ip: "81.200.149.3"
     country: "RU"
     reverse: "cache.artem-catv.ru"
     provider: "ARTEM-CATV-AS JSC Artemovskoye Interaktivnoe Televidenie"
-  - 
+  -
     ip: "66.71.191.34"
     provider: "ARUBA-ASN Aruba S.p.A."
     reverse: "ns5.9netweb.it"
     country: "IT"
-  - 
-    ip: "208.109.255.38"
-    country: "US"
-    reverse: "ns02.cashparking.com"
-    provider: "AS-26496-GO-DADDY-COM-LLC - GoDaddy.com, LLC"
-  - 
+  -
     ip: "207.230.192.254"
     country: "US"
     reverse: "dnsc2-lax.wi.centurylink.net"
     provider: "AS-5668 - CenturyTel Internet Holdings, Inc."
-  - 
+  -
     ip: "209.142.136.85"
     provider: "AS-5668 - CenturyTel Internet Holdings, Inc."
     reverse: "dnsc1-mx.la.centurylink.net"
     country: "US"
-  - 
+  -
     ip: "209.142.136.220"
     country: "US"
     reverse: "dnsc2-mx.la.centurylink.net"
     provider: "AS-5668 - CenturyTel Internet Holdings, Inc."
-  - 
+  -
     ip: "209.142.152.253"
     provider: "AS-5668 - CenturyTel Internet Holdings, Inc."
     reverse: "dnsc1-lr.oh.centurylink.net"
     country: "US"
-  - 
+  -
     ip: "209.142.152.254"
     country: "US"
     reverse: "dnsc2-lr.oh.centurylink.net"
     provider: "AS-5668 - CenturyTel Internet Holdings, Inc."
-  - 
+  -
     ip: "195.167.224.150"
     provider: "AS-COMPLETEL COMPLETEL SAS France"
     reverse: "dns2-3p.completel.net"
     country: "FR"
-  - 
+  -
     ip: "212.99.2.8"
     provider: "AS-COMPLETEL COMPLETEL SAS France"
     reverse: "reverse.completel.net"
     country: "FR"
-  - 
+  -
     ip: "213.244.5.67"
     provider: "AS-COMPLETEL COMPLETEL SAS France"
     reverse: "dns2.amitel.fr"
     country: "FR"
-  - 
+  -
     ip: "64.136.52.73"
     country: "US"
     reverse: "vgs-dns.vgs.untd.com"
     provider: "AS-NETZERO - Netzero,INC."
-  - 
+  -
     ip: "64.80.203.194"
     provider: "AS-PAETEC-NET - PaeTec Communications, Inc."
     reverse: "dns1-phi.paetec.net"
     country: "US"
-  - 
+  -
     ip: "64.80.255.102"
     country: "US"
     reverse: "dnscache-02-roc.paetec.net"
     provider: "AS-PAETEC-NET - PaeTec Communications, Inc."
-  - 
+  -
     ip: "64.80.255.103"
     provider: "AS-PAETEC-NET - PaeTec Communications, Inc."
     reverse: "dnscache-03-roc.paetec.net"
     country: "US"
-  - 
+  -
     ip: "64.80.255.240"
     country: "US"
     reverse: "dns2-roc.paetec.net"
     provider: "AS-PAETEC-NET - PaeTec Communications, Inc."
-  - 
+  -
     ip: "64.80.255.251"
     provider: "AS-PAETEC-NET - PaeTec Communications, Inc."
     reverse: "64.80.255.251"
     country: "US"
-  - 
+  -
     ip: "66.153.50.66"
     country: "US"
     reverse: "dns1-nyc.paetec.net"
     provider: "AS-PAETEC-NET - PaeTec Communications, Inc."
-  - 
+  -
     ip: "66.251.35.130"
     country: "US"
     reverse: "cachens3.paetec.net"
     provider: "AS-PAETEC-NET - PaeTec Communications, Inc."
-  - 
+  -
     ip: "207.59.153.242"
     country: "US"
     reverse: "cachens2.paetec.net"
     provider: "AS-PAETEC-NET - PaeTec Communications, Inc."
-  - 
+  -
     ip: "209.252.33.101"
     country: "US"
     reverse: "dnscache-01-chi.paetec.net"
     provider: "AS-PAETEC-NET - PaeTec Communications, Inc."
-  - 
+  -
     ip: "209.253.113.2"
     provider: "AS-PAETEC-NET - PaeTec Communications, Inc."
     reverse: "cachens1.mcleodusa.net"
     country: "US"
-  - 
+  -
     ip: "209.253.113.10"
     country: "US"
     reverse: "dnvtcouzh00cn02.mcleodusa.net"
     provider: "AS-PAETEC-NET - PaeTec Communications, Inc."
-  - 
+  -
     ip: "209.253.113.18"
     provider: "AS-PAETEC-NET - PaeTec Communications, Inc."
     reverse: "chcgilwuh53cn20.mcleodusa.net"
     country: "US"
-  - 
+  -
     ip: "66.206.19.3"
     provider: "AS-TIER - Tierpoint, LLC"
     reverse: "mta10.e-insites.com"
     country: "US"
-  - 
+  -
     ip: "212.34.160.52"
     country: "DE"
     reverse: "ns3.odn.de"
     provider: "AS12348 ODN OnlineDienst Nordbayern GmbH & Co. KG"
-  - 
+  -
     ip: "212.34.160.55"
     provider: "AS12348 ODN OnlineDienst Nordbayern GmbH & Co. KG"
     reverse: "ns1.odn.de"
     country: "DE"
-  - 
+  -
     ip: "212.34.164.70"
     country: "DE"
     reverse: "ns2.odn.de"
     provider: "AS12348 ODN OnlineDienst Nordbayern GmbH & Co. KG"
-  - 
+  -
     ip: "198.67.128.10"
     country: "US"
     reverse: "198.67.128.10"
     provider: "AS1239 SprintLink Global Network"
-  - 
+  -
     ip: "199.2.252.10"
     country: "US"
     reverse: "ns2.sprintlink.net"
     provider: "AS1239 SprintLink Global Network"
-  - 
+  -
     ip: "204.97.212.10"
     country: "US"
     reverse: "ns3.sprintlink.net"
     provider: "AS1239 SprintLink Global Network"
-  - 
+  -
     ip: "204.117.214.10"
     provider: "AS1239 SprintLink Global Network"
     reverse: "ns1.sprintlink.net"
     country: "US"
-  - 
+  -
     ip: "212.30.96.108"
     provider: "AS12626 Societe Francaise du Radiotelephone S.A"
     reverse: "108.96.30.212.rev.sfr.net"
     country: "FR"
-  - 
+  -
     ip: "212.30.96.123"
     country: "FR"
     reverse: "nsentr1.rslv.n9uf.net"
     provider: "AS12626 Societe Francaise du Radiotelephone S.A"
-  - 
+  -
     ip: "213.203.124.146"
     country: "FR"
     reverse: "smtp3.9tel.net"
     provider: "AS12626 Societe Francaise du Radiotelephone S.A"
-  - 
+  -
     ip: "213.203.124.147"
     provider: "AS12626 Societe Francaise du Radiotelephone S.A"
     reverse: "smtp4.9tel.net"
     country: "FR"
-  - 
+  -
     ip: "195.154.152.98"
     country: "FR"
     reverse: "ns1.ville-pau.fr"
     provider: "AS12876 ONLINE S.A.S."
-  - 
+  -
     ip: "195.154.223.1"
     provider: "AS12876 ONLINE S.A.S."
     reverse: "ns2.isdnet.net"
     country: "FR"
-  - 
+  -
     ip: "209.166.168.4"
     country: "US"
     reverse: "dnsext01.dns.pitdc1.stargate.net"
     provider: "AS17054 - CONTINENTAL BROADBAND PENNSYLVANIA, INC."
-  - 
+  -
     ip: "216.37.1.19"
     provider: "AS17054 - CONTINENTAL BROADBAND PENNSYLVANIA, INC."
     reverse: "ns1.nframe.com"
     country: "US"
-  - 
+  -
     ip: "81.21.68.77"
     country: "GB"
     reverse: "ns2.freewaycommerce.com"
     provider: "AS20738 Webfusion Internet Solutions"
-  - 
+  -
     ip: "217.18.80.105"
     provider: "AS29054 NSE Global ASN"
     reverse: "mx-clust1.junkscreen.com"
     country: "GB"
-  - 
+  -
     ip: "217.18.90.105"
     country: "GB"
     reverse: "smtp2.junkscreen.com"
     provider: "AS29054 NSE Global ASN"
-  - 
+  -
     ip: "193.252.247.52"
     country: "FR"
     reverse: "ns1.usei-strasbourg.net"
     provider: "AS3215 Orange S.A."
-  - 
+  -
     ip: "193.252.247.53"
     provider: "AS3215 Orange S.A."
     reverse: "ns2.usei-strasbourg.net"
     country: "FR"
-  - 
+  -
     ip: "194.2.0.20"
     country: "FR"
     reverse: "ns-cache0.oleane.net"
     provider: "AS3215 Orange S.A."
-  - 
+  -
     ip: "194.2.0.50"
     provider: "AS3215 Orange S.A."
     reverse: "ns-cache1.oleane.net"
     country: "FR"
-  - 
+  -
     ip: "194.51.149.1"
     provider: "AS3215 Orange S.A."
     reverse: "golgoth.inlandsys.com"
     country: "FR"
-  - 
+  -
     ip: "194.250.223.1"
     provider: "AS3215 Orange S.A."
     reverse: "ns1.cs3i.fr"
     country: "FR"
-  - 
+  -
     ip: "195.6.68.2"
     provider: "AS3215 Orange S.A."
     reverse: "dns.globalintranet.francetelecom.fr"
     country: "FR"
-  - 
+  -
     ip: "195.101.91.185"
     provider: "AS3215 Orange S.A."
     reverse: "ns2.spiralnet.net"
     country: "FR"
-  - 
+  -
     ip: "193.148.29.100"
     country: "ES"
     reverse: "ns.fujitsu.es"
     provider: "AS3324_FUJITSU_SPAIN FUJITSU TECHNOLOGY SOLUTIONS, S.A."
-  - 
+  -
     ip: "193.148.29.103"
     provider: "AS3324_FUJITSU_SPAIN FUJITSU TECHNOLOGY SOLUTIONS, S.A."
     reverse: "ns1.fujitsu.es"
     country: "ES"
-  - 
+  -
     ip: "195.224.180.238"
     country: "GB"
     reverse: "newtoro.pncl.co.uk"
     provider: "AS5413 Daisy Communications Ltd"
-  - 
+  -
     ip: "160.44.1.4"
     provider: "AS6878-T-SYSTEMS T-Systems International GmbH"
     reverse: "ns1.4smr.net"
     country: "DE"
-  - 
+  -
     ip: "158.43.240.4"
     country: "US"
     reverse: "cache0004.ns.eu.uu.net"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
-  - 
+  -
     ip: "62.22.102.5"
     country: "US"
     reverse: "dns.lidera.com"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
-  - 
+  -
     ip: "62.22.102.6"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
     reverse: "dns2.lidera.com"
     country: "US"
-  - 
+  -
     ip: "158.43.128.1"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
     reverse: "cache0002.ns.eu.uu.net"
     country: "US"
-  - 
+  -
     ip: "158.43.128.72"
     country: "US"
     reverse: "cache0000.ns.eu.uu.net"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
-  - 
+  -
     ip: "158.43.192.1"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
     reverse: "cache0003.ns.eu.uu.net"
     country: "US"
-  - 
+  -
     ip: "158.43.240.3"
     country: "US"
     reverse: "cache0005a.ns.eu.uu.net"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
-  - 
+  -
     ip: "193.101.111.10"
     country: "US"
     reverse: "cache0702.ns.eu.uu.net"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
-  - 
+  -
     ip: "193.101.111.20"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
     reverse: "cache0703.ns.eu.uu.net"
     country: "US"
-  - 
+  -
     ip: "194.7.1.4"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
     reverse: "cache0100.ns.eu.uu.net"
     country: "US"
-  - 
+  -
     ip: "194.98.65.65"
     country: "US"
     reverse: "cache0300.ns.eu.uu.net"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
-  - 
+  -
     ip: "194.98.65.165"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
     reverse: "cache0101.ns.eu.uu.net"
     country: "US"
-  - 
+  -
     ip: "194.98.81.133"
     country: "US"
     reverse: "194.98.81.133"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
-  - 
+  -
     ip: "194.129.23.20"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
     reverse: "newdns.zetex.com"
     country: "US"
-  - 
+  -
     ip: "194.175.236.2"
     country: "US"
     reverse: "balrog.lsy-pps.de"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
-  - 
+  -
     ip: "212.249.57.240"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
     reverse: "ns1.hugy.ch"
     country: "US"
-  - 
+  -
     ip: "213.68.194.51"
     country: "US"
     reverse: "213.68.194.51"
     provider: "AS702 Verizon Business EMEA - Commercial IP service provider in Europe"
-  - 
+  -
     ip: "212.37.208.3"
     country: "FR"
     reverse: "ns3.internet-fr.net"
     provider: "AS8784 Prosodie"
-  - 
+  -
     ip: "212.37.208.4"
     provider: "AS8784 Prosodie"
     reverse: "ns4.internet-fr.net"
     country: "FR"
-  - 
+  -
     ip: "213.151.109.1"
     provider: "ASALPI Orange Catalunya Xarxes de Telecomunicacions S.A."
     reverse: "ns1.coac.net"
     country: "ES"
-  - 
+  -
     ip: "195.242.192.2"
     country: "DK"
     reverse: "public.comflex.dk"
     provider: "ASCOMFLEX Comflex Networks ApS"
-  - 
+  -
     ip: "195.242.195.5"
     provider: "ASCOMFLEX Comflex Networks ApS"
     reverse: "ns.comflex.dk"
     country: "DK"
-  - 
+  -
     ip: "217.198.208.66"
     provider: "ASEMNET EnergiMidt A/S"
     reverse: "ns1.emnet.dk"
     country: "DK"
-  - 
+  -
     ip: "77.241.112.23"
     provider: "ASEPRESA EPRESA ENERGIA S.A.U."
     reverse: "dns1.epresa.com"
     country: "ES"
-  - 
+  -
     ip: "77.241.112.24"
     country: "ES"
     reverse: "dns2.epresa.com"
     provider: "ASEPRESA EPRESA ENERGIA S.A.U."
-  - 
+  -
     ip: "217.69.160.18"
     provider: "ASGHOSTNET GHOSTnet GmbH"
     reverse: "ns.ghostnet.de"
     country: "DE"
-  - 
+  -
     ip: "217.69.169.25"
     country: "DE"
     reverse: "dns.sectoor.de"
     provider: "ASGHOSTNET GHOSTnet GmbH"
-  - 
+  -
     ip: "81.27.226.1"
     country: "DE"
     reverse: "ns.hsl.com"
     provider: "ASHSL-AS HSL SystemDesign GmbH"
-  - 
+  -
     ip: "62.183.104.12"
     country: "RU"
     reverse: "ns.astranet.ru"
     provider: "ASI-AS OJSC Rostelecom"
-  - 
+  -
     ip: "62.183.109.34"
     provider: "ASI-AS OJSC Rostelecom"
     reverse: "medusa.astranet.ru"
     country: "RU"
-  - 
+  -
     ip: "121.52.206.130"
     country: "SG"
     reverse: "ns2.asiasoftsea.net"
     provider: "ASIASOFT-AS-AP Asiasoft Online Pte Ltd"
-  - 
+  -
     ip: "217.113.242.2"
     provider: "ASKAOSDE KAOS redes IP"
     reverse: "res.kaosredes.com"
     country: "ES"
-  - 
+  -
     ip: "81.95.128.218"
     provider: "ASN-AVANTEL-MSK Avantel, Close Joint Stock Company"
     reverse: "ns1.matrixtelecom.ru"
     country: "RU"
-  - 
+  -
     ip: "81.95.138.218"
     country: "RU"
     reverse: "synchro.matrixtelecom.net"
     provider: "ASN-AVANTEL-MSK Avantel, Close Joint Stock Company"
-  - 
+  -
     ip: "212.158.248.5"
     country: "GB"
     reverse: "mcr-dns.dslgb.com"
     provider: "ASN-CWACCESS Cable and Wireless Access Ltd"
-  - 
+  -
     ip: "212.158.248.6"
     country: "GB"
     reverse: "mcr-dns.dslgb.com"
     provider: "ASN-CWACCESS Cable and Wireless Access Ltd"
-  - 
+  -
     ip: "83.146.21.5"
     country: "GB"
     reverse: "cht-dns.dslgb.com"
     provider: "ASN-CWACCESS Cable and Wireless Access Ltd"
-  - 
+  -
     ip: "83.146.21.6"
     provider: "ASN-CWACCESS Cable and Wireless Access Ltd"
     reverse: "cht-dns.dslgb.com"
     country: "GB"
-  - 
+  -
     ip: "24.248.137.39"
     country: "US"
     reverse: "ns1.mm.at.cox.net"
     provider: "ASN-CXA-ALL-CCI-22773-RDC - Cox Communications Inc."
-  - 
+  -
     ip: "68.105.29.11"
     country: "US"
     reverse: "cdns6.cox.net"
     provider: "ASN-CXA-ALL-CCI-22773-RDC - Cox Communications Inc."
-  - 
+  -
     ip: "68.105.29.12"
     provider: "ASN-CXA-ALL-CCI-22773-RDC - Cox Communications Inc."
     reverse: "cdns7.cox.net"
     country: "US"
-  - 
+  -
     ip: "192.189.191.252"
     country: "US"
     reverse: "ns1.asymtek.com"
     provider: "ASN-CXA-ALL-CCI-22773-RDC - Cox Communications Inc."
-  - 
+  -
     ip: "216.54.2.11"
     country: "US"
     reverse: "ns2.coxfiber.net"
     provider: "ASN-CXA-ALL-CCI-22773-RDC - Cox Communications Inc."
-  - 
+  -
     ip: "216.52.129.1"
     country: "US"
     reverse: "ns1.chi.pnap.net"
     provider: "ASN-INTERNAP-BLK - Internap Network Services Corporation"
-  - 
+  -
     ip: "216.52.129.33"
     provider: "ASN-INTERNAP-BLK - Internap Network Services Corporation"
     reverse: "ns2.chi.pnap.net"
     country: "US"
-  - 
+  -
     ip: "206.231.8.2"
     country: "US"
     reverse: "ns1.netsync.net"
     provider: "ASN-NETSYNC - Dunkirk & Fredonia Telephone Company"
-  - 
+  -
     ip: "82.216.111.122"
     provider: "ASN-NUMERICABLE NUMERICABLE is a cable network operator in France, offering TV,VOICE and Internet services"
     reverse: "res2.tech.numericable.fr"
     country: "FR"
-  - 
+  -
     ip: "63.228.23.5"
     country: "US"
     reverse: "ns1.subrad.com"
     provider: "ASN-QWEST-US NOVARTIS-DMZ-US"
-  - 
+  -
     ip: "63.228.23.6"
     provider: "ASN-QWEST-US NOVARTIS-DMZ-US"
     reverse: "ns2.subrad.com"
     country: "US"
-  - 
+  -
     ip: "63.230.221.49"
     country: "US"
     reverse: "gate.georgewood.net"
     provider: "ASN-QWEST-US NOVARTIS-DMZ-US"
-  - 
+  -
     ip: "205.171.2.25"
     provider: "ASN-QWEST-US NOVARTIS-DMZ-US"
     reverse: "resolver.qwest.net"
     country: "US"
-  - 
+  -
     ip: "205.171.2.65"
     country: "US"
     reverse: "resolver.qwest.net"
     provider: "ASN-QWEST-US NOVARTIS-DMZ-US"
-  - 
+  -
     ip: "205.171.3.25"
     provider: "ASN-QWEST-US NOVARTIS-DMZ-US"
     reverse: "redirect1.qwest.net"
     country: "US"
-  - 
+  -
     ip: "205.171.3.65"
     country: "US"
     reverse: "resolver1.qwest.net"
     provider: "ASN-QWEST-US NOVARTIS-DMZ-US"
-  - 
+  -
     ip: "217.16.223.30"
     country: "GB"
     reverse: "dns0.scotnet.net"
     provider: "ASN-SCOTNET Scotnet"
-  - 
+  -
     ip: "213.158.0.16"
     provider: "ASN-SPBNIT OJSC Rostelecom"
     reverse: "ns2.spbtlg.ru"
     country: "RU"
-  - 
+  -
     ip: "81.15.197.10"
     country: "PL"
     reverse: "81.15.197.10"
     provider: "ASN-TELENERGO Exatel S.A."
-  - 
+  -
     ip: "139.130.4.4"
     provider: "ASN-TELSTRA Telstra Pty Ltd"
     reverse: "uneeda.telstra.net"
     country: "AU"
-  - 
+  -
     ip: "203.50.2.71"
     country: "AU"
     reverse: "lon-resolver.telstra.net"
     provider: "ASN-TELSTRA Telstra Pty Ltd"
-  - 
+  -
     ip: "216.87.84.211"
     provider: "ASN-VINS - ViaWest"
     reverse: "mx1.sourpuss.net"
     country: "US"
-  - 
+  -
     ip: "78.131.157.2"
     country: "PL"
     reverse: "xantos.pl"
     provider: "ASN-XANTOS Xantos Pawel Kurczak"
-  - 
+  -
     ip: "205.236.148.130"
     country: "CA"
     reverse: "galilee1.sogetel.net"
     provider: "ASN01-SOGE - SOGETEL INC"
-  - 
+  -
     ip: "205.236.148.131"
     provider: "ASN01-SOGE - SOGETEL INC"
     reverse: "galilee2.sogetel.net"
     country: "CA"
-  - 
+  -
     ip: "208.38.1.15"
     country: "CA"
     reverse: "ns2.pason.net"
     provider: "ASN852 - TELUS Communications Inc."
-  - 
+  -
     ip: "213.133.224.2"
     country: "CH"
     reverse: "ns.assolo.net"
     provider: "ASSOLO Assolo Networks SA"
-  - 
+  -
     ip: "91.138.1.128"
     country: "CH"
     reverse: "ns1.yetnet.ch"
     provider: "ASTBSUHR Technische Betriebe Suhr"
-  - 
+  -
     ip: "91.138.126.128"
     provider: "ASTBSUHR Technische Betriebe Suhr"
     reverse: "ns1.ziknet.ch"
     country: "CH"
-  - 
+  -
     ip: "62.122.208.68"
     provider: "ASTEIS-AS Torgovij Dom Asteis Ltd."
     reverse: "ns.asteis.net"
     country: "RU"
-  - 
+  -
     ip: "80.87.96.30"
     provider: "ASTPAGE-AS Astrakhan Page"
     reverse: "ns.astpage.ru"
     country: "RU"
-  - 
+  -
     ip: "195.82.134.6"
     country: "RU"
     reverse: "ns3.astrakhan.ru"
     provider: "ASTRAKHAN-DTV-AS ZAO Astrakhan Digital Television"
-  - 
+  -
     ip: "83.142.9.30"
     country: "RU"
     reverse: "ns.astelecom.ru"
     provider: "ASTRAKHAN-TELECOM-AS OOO Production-Commercial Company Astrakhan-Telecom"
-  - 
+  -
     ip: "91.191.176.254"
     provider: "ASWOCOMNET WocomNet Ltd AS-Number"
     reverse: "ns1.wocomnet.com"
     country: "RU"
-  - 
+  -
     ip: "91.191.178.20"
     country: "RU"
     reverse: "interburg.tv"
     provider: "ASWOCOMNET WocomNet Ltd AS-Number"
-  - 
+  -
     ip: "195.162.19.34"
     provider: "AS_ADAM OGIC Informatica S.L. - ADAM Internet"
     reverse: "ns1.entornodns.com"
     country: "ES"
-  - 
+  -
     ip: "212.36.64.16"
     provider: "AS_ADAM OGIC Informatica S.L. - ADAM Internet"
     reverse: "dns1.adam.es"
     country: "ES"
-  - 
+  -
     ip: "209.183.33.23"
     country: "US"
     reverse: "schinetdns.mycingular.net"
     provider: "AT&T Wireless Service"
-  - 
+  -
     ip: "209.183.48.20"
     provider: "AT&T Wireless Service"
     reverse: "ns1.mymmode.com"
     country: "US"
-  - 
+  -
     ip: "209.183.48.21"
     country: "US"
     reverse: "ns2.mymmode.com"
     provider: "AT&T Wireless Service"
-  - 
+  -
     ip: "209.183.50.151"
     provider: "AT&T Wireless Service"
     reverse: "alninetdns.mycingular.net"
     country: "US"
-  - 
+  -
     ip: "209.183.52.20"
     country: "US"
     reverse: "209-183-052-020.mobile.mymmode.com"
     provider: "AT&T Wireless Service"
-  - 
+  -
     ip: "209.183.52.21"
     provider: "AT&T Wireless Service"
     reverse: "ns3.mymmode.com"
     country: "US"
-  - 
+  -
     ip: "78.159.224.224"
     country: "RU"
     reverse: "ns1.atelperm.ru"
     provider: "ATEL-AS OJSC _Vimpelcom_"
-  - 
+  -
     ip: "79.99.216.3"
     country: "RU"
     reverse: "79.99.216.3"
     provider: "ATLLANS_AS Optixtel Ltd"
-  - 
+  -
     ip: "217.17.34.10"
     provider: "ATMAN-ISP-AS ATM S.A."
     reverse: "cns1.atman.pl"
     country: "PL"
-  - 
+  -
     ip: "217.17.34.68"
     country: "PL"
     reverse: "cns2.atman.pl"
     provider: "ATMAN-ISP-AS ATM S.A."
-  - 
+  -
     ip: "77.223.243.28"
     country: "PL"
     reverse: "ns1.atol.com.pl"
     provider: "ATOL-AS Atol sp z o.o."
-  - 
+  -
     ip: "85.219.142.1"
     provider: "ATOMNET GTS Poland Sp. z o.o."
     reverse: "gw1.knc.pl"
     country: "PL"
-  - 
+  -
     ip: "217.8.180.98"
     country: "PL"
     reverse: "tornado.webtech.pl"
     provider: "ATOMNET GTS Poland Sp. z o.o."
-  - 
+  -
     ip: "216.171.98.75"
     country: "CA"
     reverse: "ns1.netsweeper.com"
     provider: "ATRIA - Atria Networks LP."
-  - 
+  -
     ip: "216.171.98.76"
     provider: "ATRIA - Atria Networks LP."
     reverse: "ns2.netsweeper.com"
     country: "CA"
-  - 
+  -
     ip: "12.127.16.67"
     country: "US"
     reverse: "rmtu.mt.rs.els-gms.att.net"
     provider: "ATT-INTERNET4 - AT&T Services, Inc."
-  - 
+  -
     ip: "12.127.17.71"
     provider: "ATT-INTERNET4 - AT&T Services, Inc."
     reverse: "dns-rs1.bgtmo.ip.att.net"
     country: "US"
-  - 
+  -
     ip: "12.127.17.72"
     country: "US"
     reverse: "dns-rs2.bgtmo.ip.att.net"
     provider: "ATT-INTERNET4 - AT&T Services, Inc."
-  - 
+  -
     ip: "65.68.49.50"
     provider: "ATT-INTERNET4 - AT&T Services, Inc."
     reverse: "wgdns1.rcsntx.sbcglobal.net"
     country: "US"
-  - 
+  -
     ip: "65.68.49.51"
     country: "US"
     reverse: "wgdns2.rcsntx.sbcglobal.net"
     provider: "ATT-INTERNET4 - AT&T Services, Inc."
-  - 
+  -
     ip: "68.94.156.1"
     country: "US"
     reverse: "dnsr1.sbcglobal.net"
     provider: "ATT-INTERNET4 - AT&T Services, Inc."
-  - 
+  -
     ip: "68.94.157.1"
     provider: "ATT-INTERNET4 - AT&T Services, Inc."
     reverse: "dnsr2.sbcglobal.net"
     country: "US"
-  - 
+  -
     ip: "204.60.203.184"
     provider: "ATT-INTERNET4 - AT&T Services, Inc."
     reverse: "dnsnode1.mrdnct.sbcglobal.net"
     country: "US"
-  - 
+  -
     ip: "206.13.28.12"
     provider: "ATT-INTERNET4 - AT&T Services, Inc."
     reverse: "dns1.snfcca.sbcglobal.net"
     country: "US"
-  - 
+  -
     ip: "206.13.29.12"
     country: "US"
     reverse: "dns1.lsanca.sbcglobal.net"
     provider: "ATT-INTERNET4 - AT&T Services, Inc."
-  - 
+  -
     ip: "206.13.30.12"
     provider: "ATT-INTERNET4 - AT&T Services, Inc."
     reverse: "dns1.sndgca.sbcglobal.net"
     country: "US"
-  - 
+  -
     ip: "206.13.31.12"
     country: "US"
     reverse: "dns1.scrmca.sbcglobal.net"
     provider: "ATT-INTERNET4 - AT&T Services, Inc."
-  - 
+  -
     ip: "212.63.70.18"
     provider: "AUTONOMOUSSYSTEMROCKENSTEINAG Rockenstein AG"
     reverse: "ns1.hk-online.de"
     country: "DE"
-  - 
+  -
     ip: "213.214.11.188"
     country: "DE"
     reverse: "213.214.11.188"
     provider: "AUTONOMOUSSYSTEMROCKENSTEINAG Rockenstein AG"
-  - 
+  -
     ip: "195.10.244.4"
     country: "GB"
     reverse: "ns1.khoosys.net"
     provider: "AVENSYS Avensys Networks Ltd"
-  - 
+  -
     ip: "95.128.246.2"
     provider: "AVK-COM-AS AVK-Computer Ltd"
     reverse: "ns.avk-com.ru"
     country: "RU"
-  - 
+  -
     ip: "217.146.224.6"
     country: "FR"
     reverse: "ns1.axialys.net"
     provider: "AXIALYS Axialys SA"
-  - 
+  -
     ip: "200.218.192.21"
     country: "BR"
     reverse: "ns.redetaho.com.br"
     provider: "Acesso a Internet R\\195\\161pido Ltda."
-  - 
+  -
     ip: "200.218.192.22"
     provider: "Acesso a Internet R\\195\\161pido Ltda."
     reverse: "ns2.redetaho.com.br"
     country: "BR"
-  - 
+  -
     ip: "200.76.5.147"
     country: "MX"
     reverse: "static-200-76-5-147.alestra.net.mx"
     provider: "Alestra, S. de R.L. de C.V."
-  - 
+  -
     ip: "207.248.224.71"
     provider: "Alestra, S. de R.L. de C.V."
     reverse: "dns-cache-mty1.alestra.net.mx"
     country: "MX"
-  - 
+  -
     ip: "207.248.224.72"
     country: "MX"
     reverse: "dns-cache-mty2.alestra.net.mx"
     provider: "Alestra, S. de R.L. de C.V."
-  - 
+  -
     ip: "207.248.224.73"
     provider: "Alestra, S. de R.L. de C.V."
     reverse: "dns-cache-mty3.alestra.net.mx"
     country: "MX"
-  - 
+  -
     ip: "195.5.64.2"
     country: "ES"
     reverse: "ns1.landsraad.net"
     provider: "Arrakis, Servicios y comunicaciones, S.L."
-  - 
+  -
     ip: "212.59.199.6"
     provider: "Arrakis, Servicios y comunicaciones, S.L."
     reverse: "ns4.landsraad.net"
     country: "ES"
-  - 
+  -
     ip: "207.164.234.129"
     provider: "BACOM - Bell Canada"
     reverse: "mtrlpq02dnsvp1.srvr.bell.ca"
     country: "CA"
-  - 
+  -
     ip: "207.164.234.193"
     country: "CA"
     reverse: "toroon63dnsvp1.srvr.bell.ca"
     provider: "BACOM - Bell Canada"
-  - 
+  -
     ip: "194.105.156.2"
     provider: "BALTINFORM-AS Kaliningrad Center of Informatization and Technical Creativity"
     reverse: "ns.baltinform.ru"
     country: "RU"
-  - 
+  -
     ip: "69.51.76.26"
     provider: "BCI - Blackfoot Telephone Cooperative, Inc."
     reverse: "cns1.cutcom.net"
     country: "US"
-  - 
+  -
     ip: "194.78.189.180"
     country: "BE"
     reverse: "180.189-78-194.adsl-static.isp.belgacom.be"
     provider: "BELGACOM-SKYNET-AS Belgacom regional ASN"
-  - 
+  -
     ip: "205.152.6.20"
     provider: "BELLSOUTH-NET-BLK - BellSouth.net Inc."
     reverse: "ns.eng.bellsouth.net"
     country: "US"
-  - 
+  -
     ip: "205.152.37.23"
     country: "US"
     reverse: "dns.asm.bellsouth.net"
     provider: "BELLSOUTH-NET-BLK - BellSouth.net Inc."
-  - 
+  -
     ip: "83.221.164.190"
     country: "RU"
     reverse: "ns2.beltelecom.ru"
     provider: "BELTELECOM ZAO _Sviaz Telecom_"
-  - 
+  -
     ip: "134.60.1.111"
     provider: "BELWUE Landeshochschulnetz Baden-Wuerttemberg (BelWue)"
     reverse: "dns.rz.uni-ulm.de"
     country: "EU"
-  - 
+  -
     ip: "81.218.119.11"
     country: "IL"
     reverse: "bzq-218-119-11.red.bezeqint.net"
     provider: "BEZEQ-INTERNATIONAL-AS Bezeqint Internet Backbone"
-  - 
+  -
     ip: "216.185.192.1"
     provider: "BHI-AS1 - BHI Advanced Internet Inc."
     reverse: "ns1.bhi.com"
     country: "US"
-  - 
+  -
     ip: "216.185.192.2"
     country: "US"
     reverse: "ns2.bhi.com"
     provider: "BHI-AS1 - BHI Advanced Internet Inc."
-  - 
+  -
     ip: "207.5.128.10"
     provider: "BIDDEFORD1 - Biddeford Internet Corp"
     reverse: "ns2.gwi.net"
     country: "US"
-  - 
+  -
     ip: "207.5.128.122"
     country: "US"
     reverse: "nightcrawler.gwi.net"
     provider: "BIDDEFORD1 - Biddeford Internet Corp"
-  - 
+  -
     ip: "62.91.2.20"
     country: "DE"
     reverse: "ns.bisping.de"
     provider: "BISPING Bisping & Bisping GmbH & Co. KG"
-  - 
+  -
     ip: "210.158.32.1"
     provider: "BIT-ISLE Bit-isle Co.,Ltd."
     reverse: "ns1.servance.ne.jp"
     country: "JP"
-  - 
+  -
     ip: "216.183.90.190"
     country: "CA"
     reverse: "ns2.blink.ca"
     provider: "BLINK-AS2 - RCP"
-  - 
+  -
     ip: "208.25.96.18"
     provider: "BLOOMINGDALE-COMMUNICATIONS - Bloomingdale Communications Inc."
     reverse: "ns2.btc-bci.com"
     country: "US"
-  - 
+  -
     ip: "62.244.88.10"
     country: "FR"
     reverse: "dns.option-service.com"
     provider: "BLUEGIX BLUEGIX"
-  - 
+  -
     ip: "62.244.109.18"
     provider: "BLUEGIX BLUEGIX"
     reverse: "nsl.fujitsu.fr"
     country: "FR"
-  - 
+  -
     ip: "89.107.24.50"
     country: "RU"
     reverse: "89.107.24.50"
     provider: "BORTELECOM-AS Closed Joint-Stock Company _Management Company _Business Technologies and Communications_"
-  - 
+  -
     ip: "217.78.80.70"
     provider: "BORWOOD-UK-AS Borwood UK Network"
     reverse: "ns1.borwood.net"
     country: "GB"
-  - 
+  -
     ip: "69.144.49.29"
     country: "US"
     reverse: "gdjco001dns.ext.bresnan.net"
     provider: "BRESNAN-AS - Bresnan Communications, LLC."
-  - 
+  -
     ip: "69.145.232.4"
     provider: "BRESNAN-AS - Bresnan Communications, LLC."
     reverse: "chywy001dns.ext.bresnan.net"
     country: "US"
-  - 
+  -
     ip: "69.145.248.50"
     country: "US"
     reverse: "blnmt002dns.ext.bresnan.net"
     provider: "BRESNAN-AS - Bresnan Communications, LLC."
-  - 
+  -
     ip: "69.146.17.2"
     provider: "BRESNAN-AS - Bresnan Communications, LLC."
     reverse: "mslmt001dns.ext.bresnan.net"
     country: "US"
-  - 
+  -
     ip: "69.146.17.3"
     country: "US"
     reverse: "mslmt002dns.ext.bresnan.net"
     provider: "BRESNAN-AS - Bresnan Communications, LLC."
-  - 
+  -
     ip: "64.135.1.20"
     country: "US"
     reverse: "dns1.host.net"
     provider: "BROADBANDONE - BroadbandONE, Inc."
-  - 
+  -
     ip: "64.135.1.22"
     provider: "BROADBANDONE - BroadbandONE, Inc."
     reverse: "ns1.host.net"
     country: "US"
-  - 
+  -
     ip: "216.242.0.15"
     provider: "BROADBANDONE - BroadbandONE, Inc."
     reverse: "ns2-auth.webunited.net"
     country: "US"
-  - 
+  -
     ip: "216.242.0.34"
     country: "US"
     reverse: "ns1.webunited.net"
     provider: "BROADBANDONE - BroadbandONE, Inc."
-  - 
+  -
     ip: "193.104.152.32"
     provider: "BROOKLANDCOMP-AS Brookland Computer Services Limited"
     reverse: "ns5.brookcom.net"
     country: "GB"
-  - 
+  -
     ip: "193.201.185.2"
     provider: "BROOKLANDCOMP-AS Brookland Computer Services Limited"
     reverse: "ns3.brookcom.net"
     country: "GB"
-  - 
+  -
     ip: "62.122.184.81"
     country: "CZ"
     reverse: "mx.online.bryansk.ru"
     provider: "BRYANSK-AS Sviaz-Service-Internet Ltd"
-  - 
+  -
     ip: "212.73.209.34"
     country: "FR"
     reverse: "ns1.bsocom.com"
     provider: "BSOCOM BSO Network Solutions SAS"
-  - 
+  -
     ip: "212.73.209.226"
     provider: "BSOCOM BSO Network Solutions SAS"
     reverse: "ns2.bsocom.com"
     country: "FR"
-  - 
+  -
     ip: "195.182.110.132"
     provider: "BT British Telecommunications plc"
     reverse: "dns-fra.de.ignite.net"
     country: "GB"
-  - 
+  -
     ip: "192.92.81.10"
     country: "NL"
     reverse: "dnshk.info.net"
     provider: "BT-INFONET-EUROPE British Telecommunications plc"
-  - 
+  -
     ip: "192.237.125.2"
     provider: "BT-INFONET-EUROPE British Telecommunications plc"
     reverse: "dns1.info.net"
     country: "NL"
-  - 
+  -
     ip: "62.6.40.162"
     country: "GB"
     reverse: "indnsc70.ukcore.bt.net"
     provider: "BT-UK-AS BTnet UK Regional network"
-  - 
+  -
     ip: "194.72.9.38"
     country: "GB"
     reverse: "ns8.bt.net"
     provider: "BT-UK-AS BTnet UK Regional network"
-  - 
+  -
     ip: "194.72.9.34"
     country: "GB"
     reverse: "bcn.customer.bt.net"
     provider: "BT-UK-AS BTnet UK Regional network"
-  - 
+  -
     ip: "194.72.0.98"
     country: "GB"
     reverse: "indnsc60.bt.net"
     provider: "BT-UK-AS BTnet UK Regional network"
-  - 
+  -
     ip: "194.72.0.114"
     country: "GB"
     reverse: "indnsc61.ukcore.bt.net"
     provider: "BT-UK-AS BTnet UK Regional network"
-  - 
+  -
     ip: "194.74.65.68"
     country: "GB"
     reverse: "indnsc40.bt.net"
     provider: "BT-UK-AS BTnet UK Regional network"
-  - 
+  -
     ip: "194.73.82.242"
     country: "GB"
     reverse: "indnsc50.bt.net"
     provider: "BT-UK-AS BTnet UK Regional network"
-  - 
+  -
     ip: "194.73.96.50"
     provider: "BT-UK-AS BTnet UK Regional network"
     reverse: "ns1.bull.co.uk"
     country: "GB"
-  - 
+  -
     ip: "129.185.32.9"
     provider: "BULL-NETWORK for further information please visit http://www.bull.com"
     reverse: "dns3.cce.integris.fr"
     country: "US"
-  - 
+  -
     ip: "212.0.76.66"
     provider: "BURNET-AS OJSC _AK Mobiltelecom_"
     reverse: "tranz1.ru"
     country: "RU"
-  - 
+  -
     ip: "213.138.101.252"
     country: "GB"
     reverse: "wally.opennicproject.org.uk"
     provider: "BYTEMARK-AS Bytemark Computer Consulting Ltd"
-  - 
+  -
     ip: "194.1.148.1"
     provider: "C2C-AS C2C Limited"
     reverse: "lon-cr01-sov.c2cvoip.co.uk"
     country: "GB"
-  - 
+  -
     ip: "77.244.128.60"
     provider: "CABLECOM-AS Cablecom Networking Limited"
     reverse: "proxy0.ixn.inuknetworks.com"
     country: "GB"
-  - 
+  -
     ip: "77.244.128.61"
     country: "GB"
     reverse: "proxy1.ixn.inuknetworks.com"
     provider: "CABLECOM-AS Cablecom Networking Limited"
-  - 
+  -
     ip: "77.244.130.2"
     provider: "CABLECOM-AS Cablecom Networking Limited"
     reverse: "ns0.rbsov.as42689.net"
     country: "GB"
-  - 
+  -
     ip: "77.244.130.10"
     country: "GB"
     reverse: "ns0.thdo.as42689.net"
     provider: "CABLECOM-AS Cablecom Networking Limited"
-  - 
+  -
     ip: "216.2.192.32"
     country: "US"
     reverse: "216.2.192.32"
     provider: "CABLEVISION-CORP - Cablevision Systems Corp."
-  - 
+  -
     ip: "158.140.1.253"
     provider: "CADENCE - Cadence Design Systems, Inc."
     reverse: "ns.cadence.com"
     country: "US"
-  - 
+  -
     ip: "85.238.5.5"
     country: "ES"
     reverse: "ns1.cartagon.net"
     provider: "CARTAGON Cartagon AS41721"
-  - 
+  -
     ip: "216.135.31.130"
     provider: "CCC-ASN-1 - Cinergy Communications"
     reverse: "ns2.muhlon.com"
     country: "US"
-  - 
+  -
     ip: "69.28.104.5"
     country: "US"
     reverse: "ns2.telekenex.com"
     provider: "CCDT-AS - Telekenex Inc"
-  - 
+  -
     ip: "198.190.226.3"
     country: "US"
     reverse: "pgh.nauticom.net"
     provider: "CCI-PA-AS-1 - Consolidated Communications, Inc."
-  - 
+  -
     ip: "195.68.195.68"
     provider: "CCI-PARIS Chambre de commerce et d_Industrie de Paris"
     reverse: "ns1.ccip.fr"
     country: "FR"
-  - 
+  -
     ip: "205.242.187.234"
     country: "US"
     reverse: "dns1.primary.net"
     provider: "CDM - CDM"
-  - 
+  -
     ip: "93.157.233.3"
     provider: "CDMS OOO Creative Direct Marketing Solutions"
     reverse: "mail.lubertsi.net"
     country: "RU"
-  - 
+  -
     ip: "208.1.60.15"
     country: "US"
     reverse: "fatb.celito.net"
     provider: "CELITO-1 - Celito Communications Inc."
-  - 
+  -
     ip: "217.30.49.100"
     country: "DE"
     reverse: "ns1.as29145.net"
     provider: "CENTAUR-GMBH-AS CENTAUR GmbH Internet Service Provider"
-  - 
+  -
     ip: "193.135.146.10"
     country: "CH"
     reverse: "ns.centralnet.ch"
     provider: "CENTRALNET CNL CentralNet GmbH, Switzerland"
-  - 
+  -
     ip: "89.111.189.130"
     country: "RU"
     reverse: "c1225.colo.hc.ru"
     provider: "CENTROHOST-AS CJSC Registrar R01"
-  - 
+  -
     ip: "87.238.112.38"
     country: "DE"
     reverse: "ns1.ce-tel.net"
     provider: "CETEL CeTEL GmbH"
-  - 
+  -
     ip: "91.151.144.106"
     country: "DE"
     reverse: "ns2.ce-tel.net"
     provider: "CETEL CeTEL GmbH"
-  - 
+  -
     ip: "77.236.43.5"
     provider: "CHANT-AS Chant-SCC"
     reverse: "ns.icp.ac.ru"
     country: "RU"
-  - 
-    ip: "24.158.96.131"
-    country: "US"
-    reverse: "ns4.chartertn.net"
-    provider: "CHARTER-NET-HKY-NC - Charter Communications"
-  - 
+  -
     ip: "216.167.223.12"
     country: "US"
     reverse: "dns1.chaska.net"
     provider: "CHASKANET - CITY OF CHASKA CHASKANET"
-  - 
+  -
     ip: "61.163.252.30"
     country: "CN"
     reverse: "hn.ly.kd.adsl"
     provider: "CHINA169-BACKBONE CNCGROUP China169 Backbone"
-  - 
+  -
     ip: "61.139.54.66"
     provider: "CHINANET-BACKBONE No.31,Jin-rong Street"
     reverse: "61.139.54.66"
     country: "CN"
-  - 
+  -
     ip: "114.114.114.114"
     country: "CN"
     reverse: "public1.114dns.com"
     provider: "CHINANET-BACKBONE No.31,Jin-rong Street"
-  - 
+  -
     ip: "66.51.128.240"
     provider: "CIPHERKEY - Cipherkey Exchange Corp."
     reverse: "ns4.dns.aebc.com"
     country: "CA"
-  - 
+  -
     ip: "66.51.128.241"
     country: "CA"
     reverse: "ns5.dns.aebc.com"
     provider: "CIPHERKEY - Cipherkey Exchange Corp."
-  - 
+  -
     ip: "209.53.200.2"
     provider: "CIPHERKEY - Cipherkey Exchange Corp."
     reverse: "ns1.dns.aebc.com"
     country: "CA"
-  - 
+  -
     ip: "209.53.200.3"
     country: "CA"
     reverse: "ns2.dns.aebc.com"
     provider: "CIPHERKEY - Cipherkey Exchange Corp."
-  - 
+  -
     ip: "212.86.160.70"
     country: "DE"
     reverse: "ns1.circular.net"
     provider: "CIRC-AS circular Informationssysteme GmbH"
-  - 
+  -
     ip: "213.153.64.1"
     provider: "CIRC-AS circular Informationssysteme GmbH"
     reverse: "ns2.circular.net"
     country: "DE"
-  - 
+  -
     ip: "148.84.30.6"
     provider: "CITY-UNIVERSITY-OF-NEW-YORK - City University of New York"
     reverse: "ns2.lehman.cuny.edu"
     country: "US"
-  - 
+  -
     ip: "194.29.180.1"
     provider: "CITYMEDIANET-AS CityMedia Net"
     reverse: "citymedia.pl"
     country: "PL"
-  - 
+  -
     ip: "64.181.43.34"
     country: "US"
     reverse: "ns1.mypcstv.com"
     provider: "CITYNET - CityNet"
-  - 
+  -
     ip: "66.118.80.4"
     provider: "CITYNET - CityNet"
     reverse: "ns1.wvinternetservices.com"
     country: "US"
-  - 
+  -
     ip: "91.103.0.1"
     country: "IE"
     reverse: "ns-001.chipeservices.com"
     provider: "CIX-AS Chip Electronic Services Limited"
-  - 
+  -
     ip: "195.170.96.2"
     country: "GB"
     reverse: "resolver6.de.clara.net"
     provider: "CLARANET-AS ClaraNET LTD"
-  - 
+  -
     ip: "195.170.97.254"
     provider: "CLARANET-AS ClaraNET LTD"
     reverse: "resolver5.de.clara.net"
     country: "GB"
-  - 
+  -
     ip: "212.6.140.65"
     country: "GB"
     reverse: "ns0.cnt.net"
     provider: "CLARANET-AS ClaraNET LTD"
-  - 
+  -
     ip: "212.66.0.1"
     provider: "CLARANET-AS ClaraNET LTD"
     reverse: "resolver4.de.clara.net"
     country: "GB"
-  - 
+  -
     ip: "212.66.1.1"
     country: "GB"
     reverse: "resolver3.de.clara.net"
     provider: "CLARANET-AS ClaraNET LTD"
-  - 
+  -
     ip: "212.82.225.7"
     provider: "CLARANET-AS ClaraNET LTD"
     reverse: "resolver0.de.clara.net"
     country: "GB"
-  - 
+  -
     ip: "212.82.225.12"
     country: "GB"
     reverse: "resolver2.de.clara.net"
     provider: "CLARANET-AS ClaraNET LTD"
-  - 
+  -
     ip: "212.82.226.212"
     provider: "CLARANET-AS ClaraNET LTD"
     reverse: "resolver1.de.clara.net"
     country: "GB"
-  - 
+  -
     ip: "64.13.24.5"
     country: "US"
     reverse: "64-13-24-5.ecl.clearwire-dns.net"
     provider: "CLEARWIRE - CLEAR WIRELESS LLC"
-  - 
+  -
     ip: "64.13.48.12"
     provider: "CLEARWIRE - CLEAR WIRELESS LLC"
     reverse: "64-13-48-12.war.clearwire-dns.net"
     country: "US"
-  - 
+  -
     ip: "64.13.115.12"
     country: "US"
     reverse: "64.13.115.12"
     provider: "CLEARWIRE - CLEAR WIRELESS LLC"
-  - 
+  -
     ip: "75.94.255.12"
     country: "US"
     reverse: "75-94-255-12.gar.clearwire-wmx.net"
     provider: "CLEARWIRE - CLEAR WIRELESS LLC"
-  - 
+  -
     ip: "178.22.71.56"
     country: "CH"
     reverse: "sns.cloudsigma.com"
     provider: "CLOUDSIGMA-AS CLOUDSIGMA AG"
-  - 
+  -
     ip: "70.90.33.94"
     provider: "CMCS - Comcast Cable Communications, Inc."
     reverse: "70-90-33-94-michigan.hfc.comcastbusiness.net"
     country: "US"
-  - 
+  -
     ip: "183.203.164.146"
     provider: "CMNET-SHANXI-AP China Mobile communications corporation"
     reverse: "183.203.164.146"
     country: "CN"
-  - 
+  -
     ip: "211.161.192.73"
     country: "CN"
     reverse: "dns2.gwbnsh.net.cn"
     provider: "CNIX-AP China Networks Inter-Exchange"
-  - 
+  -
     ip: "219.233.241.166"
     provider: "CNNIC-CN-COLNET Oriental Cable Network Co., Ltd."
     reverse: "zj-ns1.cableplus.com.cn"
     country: "CN"
-  - 
+  -
     ip: "203.119.25.4"
     country: "CN"
     reverse: "a.cnnic.cn"
     provider: "CNNIC-CRITICAL-AP China Internet Network Infomation Center"
-  - 
+  -
     ip: "203.119.27.4"
     provider: "CNNIC-CRITICAL-AP China Internet Network Infomation Center"
     reverse: "c.cnnic.cn"
     country: "CN"
-  - 
+  -
     ip: "38.102.194.214"
     provider: "COGENT Cogent/PSI"
     reverse: "res2-herndon.sys.cogentco.com"
     country: "US"
-  - 
+  -
     ip: "38.112.17.138"
     country: "US"
     reverse: "res1-nyc.sys.cogentco.com"
     provider: "COGENT Cogent/PSI"
-  - 
+  -
     ip: "38.112.17.142"
     provider: "COGENT Cogent/PSI"
     reverse: "res2-nyc.sys.cogentco.com"
     country: "US"
-  - 
+  -
     ip: "66.28.0.45"
     country: "US"
     reverse: "res1.dns.cogentco.com"
     provider: "COGENT Cogent/PSI"
-  - 
+  -
     ip: "66.28.0.61"
     provider: "COGENT Cogent/PSI"
     reverse: "res2.dns.cogentco.com"
     country: "US"
-  - 
+  -
     ip: "66.28.28.210"
     country: "US"
     reverse: "res2-la.sys.cogentco.com"
     provider: "COGENT Cogent/PSI"
-  - 
+  -
     ip: "66.250.7.154"
     country: "US"
     reverse: "res1-herndon.sys.cogentco.com"
     provider: "COGENT Cogent/PSI"
-  - 
+  -
     ip: "149.5.32.2"
     country: "US"
     reverse: "pop.rivertower.ie"
     provider: "COGENT Cogent/PSI"
-  - 
+  -
     ip: "149.5.32.4"
     provider: "COGENT Cogent/PSI"
     reverse: "relay.rivertower.ie"
     country: "US"
-  - 
+  -
     ip: "149.6.140.30"
     country: "US"
     reverse: "res2-fra03.sys.cogentco.com"
     provider: "COGENT Cogent/PSI"
-  - 
+  -
     ip: "195.210.48.3"
     provider: "COGENT Cogent/PSI"
     reverse: "ns04.quat.net"
     country: "US"
-  - 
+  -
     ip: "216.152.64.199"
     country: "US"
     reverse: "ns1.webchat.org"
     provider: "COGENT Cogent/PSI"
-  - 
+  -
     ip: "217.71.116.60"
     provider: "COGENT Cogent/PSI"
     reverse: "217.71.116.60"
     country: "US"
-  - 
+  -
     ip: "142.77.49.31"
     provider: "COLO-PREM-VZB - Verizon Online LLC"
     reverse: "142.77.49.31"
     country: "US"
-  - 
+  -
     ip: "72.249.0.34"
     provider: "COLO4 - Colo4, LLC"
     reverse: "nsa.colo4dallas.net.0.249.72.in-addr.arpa"
     country: "US"
-  - 
+  -
     ip: "72.249.9.169"
     country: "US"
     reverse: "ns2.alliance.com"
     provider: "COLO4 - Colo4, LLC"
-  - 
+  -
     ip: "206.123.64.245"
     country: "US"
     reverse: "ns1.colo4dallas.net"
     provider: "COLO4 - Colo4, LLC"
-  - 
+  -
     ip: "206.123.113.254"
     provider: "COLO4 - Colo4, LLC"
     reverse: "nsc-dl2.rimuhosting.com"
     country: "US"
-  - 
+  -
     ip: "72.249.191.254"
     provider: "COLO4-CO - Colo4, LLC"
     reverse: "nsc-dl1.rimuhosting.com"
     country: "US"
-  - 
+  -
     ip: "119.252.27.103"
     country: "AU"
     reverse: "119.252.27.103"
     provider: "COLOCITY-AS-AP Colocity Pty Ltd"
-  - 
+  -
     ip: "66.207.160.111"
     country: "US"
     reverse: "111.160.207.66.in-addr.arpa"
     provider: "COLOGUYS - ColoGuys, Inc."
-  - 
+  -
     ip: "62.97.84.4"
     provider: "COLT COLT Technology Services Group Limited"
     reverse: "dash.futurnet.es"
     country: "GB"
-  - 
+  -
     ip: "193.110.81.4"
     country: "GB"
     reverse: "ns3.webline.be"
     provider: "COLT COLT Technology Services Group Limited"
-  - 
+  -
     ip: "193.110.81.5"
     provider: "COLT COLT Technology Services Group Limited"
     reverse: "ns1.webline.be"
     country: "GB"
-  - 
+  -
     ip: "213.27.209.8"
     provider: "COLT COLT Technology Services Group Limited"
     reverse: "ns.drac.net"
     country: "GB"
-  - 
+  -
     ip: "213.27.209.53"
     country: "GB"
     reverse: "ns0.drac.net"
     provider: "COLT COLT Technology Services Group Limited"
-  - 
-    ip: "68.87.66.234"
-    provider: "COMCAST-36732 - Comcast Cable Communications, Inc."
-    reverse: "cns-spf.cmc.co.ndcwest.comcast.net"
-    country: "US"
-  - 
+  -
     ip: "62.117.90.2"
     provider: "COMCOR-AS AS for Moscow Telecommunication Corporation (COMCOR)"
     reverse: "ns.msiu.ru"
     country: "RU"
-  - 
+  -
     ip: "82.138.17.132"
     country: "RU"
     reverse: "dns3.rs-online.ru"
     provider: "COMCOR-AS AS for Moscow Telecommunication Corporation (COMCOR)"
-  - 
+  -
     ip: "212.45.24.35"
     provider: "COMCOR-AS AS for Moscow Telecommunication Corporation (COMCOR)"
     reverse: "35.24.45.212.in-addr.sktv.ru"
     country: "RU"
-  - 
+  -
     ip: "89.104.194.142"
     country: "DK"
     reverse: "ns2.censurfridns.dk"
     provider: "COMENDO-AS Comendo A/S"
-  - 
+  -
     ip: "203.221.45.7"
     provider: "COMINDICO-AP SOUL Converged Communications Australia"
     reverse: "ns1.bluefirems.com.au"
     country: "AU"
-  - 
+  -
     ip: "66.203.66.203"
     provider: "COMMRAIL - Access Northeast Inc."
     reverse: "ns.axsne.net"
     country: "US"
-  - 
+  -
     ip: "66.203.72.10"
     country: "US"
     reverse: "ns2.axsne.net"
     provider: "COMMRAIL - Access Northeast Inc."
-  - 
+  -
     ip: "79.170.161.17"
     provider: "COMRISE-AS LLC Modern Communication Technologies"
     reverse: "ns2.sts-company.ru"
     country: "RU"
-  - 
+  -
     ip: "92.39.64.228"
     country: "RU"
     reverse: "ns1.kirov.comstar-r.ru"
     provider: "COMSTAR-KRV-AS Mobile Telesystems OJSC"
-  - 
+  -
     ip: "216.22.81.60"
     country: "US"
     reverse: "216.22.81.60"
     provider: "COMVOZ-US - Comvoz Communication LLC"
-  - 
+  -
     ip: "91.90.160.5"
     provider: "CONNECTA-AS Connecta sp. z o.o."
     reverse: "ns2.connecta.pl"
     country: "PL"
-  - 
+  -
     ip: "195.149.104.186"
     provider: "CONNECTO-AS CJSC Connecto"
     reverse: "ns3.connecto.tv"
     country: "RU"
-  - 
+  -
     ip: "80.64.54.19"
     provider: "CONTROLCIRCLE-UK-AS Control Circle Ltd"
     reverse: "mail2.netxtra.net"
     country: "GB"
-  - 
+  -
     ip: "195.14.50.21"
     provider: "CORBINA-AS OJSC _Vimpelcom_"
     reverse: "earth.corbina.net"
     country: "RU"
-  - 
+  -
     ip: "216.19.223.34"
     provider: "CORESPACE-DAL - CoreSpace, Inc."
     reverse: "ns2.inficad.com"
     country: "US"
-  - 
+  -
     ip: "87.247.246.248"
     provider: "COREUK Core Education and Consulting Solutions (UK) Ltd"
     reverse: "dns2.progrid.net"
     country: "GB"
-  - 
+  -
     ip: "193.186.162.3"
     country: "GB"
     reverse: "ns1.corpolink.com"
     provider: "CORPOLINK-AS CorpoLink Ltd."
-  - 
+  -
     ip: "195.170.228.107"
     country: "RU"
     reverse: "ns1.vpk.ru"
     provider: "COSMOS-SN-AS Space Research Institute of Russian Academy of Sciences"
-  - 
+  -
     ip: "195.170.229.100"
     provider: "COSMOS-SN-AS Space Research Institute of Russian Academy of Sciences"
     reverse: "ns2.vpk.ru"
     country: "RU"
-  - 
+  -
     ip: "195.184.78.33"
     country: "RU"
     reverse: "ns.shadrinsk.net"
     provider: "COURIER-PLUS-AS Courier Plus Ltd."
-  - 
+  -
     ip: "89.255.96.3"
     country: "RU"
     reverse: "ns0.cplus.ru"
     provider: "CPLUS1-AS CJSC TK Convey Plus"
-  - 
+  -
     ip: "89.255.99.131"
     provider: "CPLUS1-AS CJSC TK Convey Plus"
     reverse: "ns1.cplus.ru"
     country: "RU"
-  - 
+  -
     ip: "193.254.184.231"
     country: "DE"
     reverse: "ns1.dnsresolve.net"
     provider: "CRONON-AS Vautron Rechenzentrum AG"
-  - 
+  -
     ip: "194.169.244.34"
     provider: "CROSSPOINT-AS Crosspoint Colocation And Hosting Limited"
     reverse: "ns6.adweb.co.uk"
     country: "GB"
-  - 
+  -
     ip: "147.29.10.55"
     provider: "CSC Danmark A/S"
     reverse: "ns2.sdn.dk"
     country: "DK"
-  - 
+  -
     ip: "147.29.37.19"
     country: "DK"
     reverse: "ns3.csc.dk"
     provider: "CSC Danmark A/S"
-  - 
+  -
     ip: "147.29.37.20"
     provider: "CSC Danmark A/S"
     reverse: "ns4.csc.dk"
     country: "DK"
-  - 
+  -
     ip: "212.15.64.21"
     country: "GB"
     reverse: "ns0.csi.net.uk"
     provider: "CSI-NETWORKS Clements Shine Investments Limited"
-  - 
+  -
     ip: "203.146.237.237"
     country: "TH"
     reverse: "ns01.csloxinfo.com"
     provider: "CSLOXINFO-AS-AP CS LOXINFO PUBLIC COMPANY LIMITED"
-  - 
+  -
     ip: "217.175.129.60"
     provider: "CSSMPS-AS Central Switching Station of Ministry Railway Transport"
     reverse: "lion.css-rzd.ru"
     country: "RU"
-  - 
+  -
     ip: "202.38.128.58"
     country: "CN"
     reverse: "dns.ihep.ac.cn"
     provider: "CSTNET-AS-AP Computer Network Information Center"
-  - 
+  -
     ip: "130.150.102.20"
     provider: "CSUNET-NW - California State University Network"
     reverse: "ns2.csu.net"
     country: "US"
-  - 
+  -
     ip: "130.150.102.100"
     country: "US"
     reverse: "ns1.csu.net"
     provider: "CSUNET-NW - California State University Network"
-  - 
+  -
     ip: "137.145.204.10"
     provider: "CSUNET-NW - California State University Network"
     reverse: "ns3.csu.net"
     country: "US"
-  - 
+  -
     ip: "206.78.236.20"
     provider: "CSUNET-NW - California State University Network"
     reverse: "ns1.mariposa.k12.ca.us"
     country: "US"
-  - 
+  -
     ip: "205.225.182.1"
     provider: "CTA-42-AS1226 - California Technology Agency"
     reverse: "ns2.net.ca.gov"
     country: "US"
-  - 
+  -
     ip: "80.246.64.2"
     provider: "CTCTVER OJSC Rostelecom"
     reverse: "ns.tvcom.ru"
     country: "RU"
-  - 
+  -
     ip: "61.236.93.33"
     country: "CN"
     reverse: "61.236.93.33"
     provider: "CTTNET China TieTong Telecommunications Corporation"
-  - 
+  -
     ip: "61.236.93.34"
     provider: "CTTNET China TieTong Telecommunications Corporation"
     reverse: "61.236.93.34"
     country: "CN"
-  - 
+  -
     ip: "211.98.4.1"
     provider: "CTTNET China TieTong Telecommunications Corporation"
     reverse: "211.98.4.1"
     country: "CN"
-  - 
+  -
     ip: "65.163.107.11"
     country: "US"
     reverse: "ns1.ctusa.net"
     provider: "CTUSA-NET - Multiband"
-  - 
+  -
     ip: "134.7.32.77"
     provider: "CURTIN-UNI-AS-AP Curtin University"
     reverse: "ns1.curtin.edu.au"
     country: "AU"
-  - 
+  -
     ip: "141.1.1.1"
     provider: "CW Cable and Wireless Worldwide plc"
     reverse: "cns1.cw.net"
     country: "EU"
-  - 
+  -
     ip: "141.1.27.249"
     country: "EU"
     reverse: "euro-cns1.cw.net"
     provider: "CW Cable and Wireless Worldwide plc"
-  - 
+  -
     ip: "194.6.79.163"
     country: "EU"
     reverse: "ns1.cwci.net"
     provider: "CW Cable and Wireless Worldwide plc"
-  - 
+  -
     ip: "195.27.150.42"
     country: "EU"
     reverse: "195.27.150.42"
     provider: "CW Cable and Wireless Worldwide plc"
-  - 
+  -
     ip: "212.137.64.13"
     country: "EU"
     reverse: "ns1.swi.uk.cw.net"
     provider: "CW Cable and Wireless Worldwide plc"
-  - 
+  -
     ip: "212.137.65.14"
     provider: "CW Cable and Wireless Worldwide plc"
     reverse: "ns2.swi.uk.cw.net"
     country: "EU"
-  - 
+  -
     ip: "193.200.81.48"
     country: "GB"
     reverse: "ns.supremeservers.net"
     provider: "CWCS-PS Compuweb Communications Services Limited"
-  - 
+  -
     ip: "194.116.175.15"
     provider: "CWCS-PS Compuweb Communications Services Limited"
     reverse: "ns.serversurance.co.uk"
     country: "GB"
-  - 
+  -
     ip: "193.223.240.241"
     provider: "CYBERLINK Cyberlink AG"
     reverse: "ns.simmcomm.ch"
     country: "CH"
-  - 
+  -
     ip: "193.223.241.241"
     country: "CH"
     reverse: "ns2.simmcomm.ch"
     provider: "CYBERLINK Cyberlink AG"
-  - 
+  -
     ip: "149.156.12.250"
     country: "PL"
     reverse: "amicus.cm-uj.krakow.pl"
     provider: "CYFRONET-AS Metropolitan Area Network Autonomous System"
-  - 
+  -
     ip: "149.156.64.210"
     provider: "CYFRONET-AS Metropolitan Area Network Autonomous System"
     reverse: "theta.uoks.uj.edu.pl"
     country: "PL"
-  - 
+  -
     ip: "149.156.130.29"
     country: "PL"
     reverse: "kubus.wis.pk.edu.pl"
     provider: "CYFRONET-AS Metropolitan Area Network Autonomous System"
-  - 
+  -
     ip: "193.193.74.130"
     provider: "CYFRONET-AS2 Metropolitan Area Network Autonomous System"
     reverse: "solaris.clico.krakow.pl"
     country: "PL"
-  - 
+  -
     ip: "193.33.174.3"
     provider: "CZAJEN FPUH Czajen Krzysztof Czaja"
     reverse: "dns.czajen.pl"
     country: "CZ"
-  - 
+  -
     ip: "193.33.175.10"
     country: "CZ"
     reverse: "10.175.33.193.in-addr.arpa.czajen.pl"
     provider: "CZAJEN FPUH Czajen Krzysztof Czaja"
-  - 
+  -
     ip: "212.87.241.6"
     country: "PL"
     reverse: "dns3.pcz.pl"
     provider: "CZESTMAN-COM-AS Non-academic AS dedicated to Metropolitan Area Network"
-  - 
+  -
     ip: "200.95.144.4"
     provider: "Cablemas Telecomunicaciones SA de CV"
     reverse: "cva2.cableonline.com.mx"
     country: "MX"
-  - 
+  -
     ip: "91.210.24.22"
     provider: "DAGOMYS-AS Dagomys Telecom LLC"
     reverse: "ns1.dagotel.ru"
     country: "RU"
-  - 
+  -
     ip: "208.76.50.50"
     provider: "DATA-SUBSYSTEMS-INC-AS - Data Subsystems Inc"
     reverse: "ip-50.50.76.208.datasub.com"
     country: "US"
-  - 
+  -
     ip: "208.76.51.51"
     country: "US"
     reverse: "ip-51.51.76.208.datasub.com"
     provider: "DATA-SUBSYSTEMS-INC-AS - Data Subsystems Inc"
-  - 
+  -
     ip: "195.26.96.2"
     provider: "DATAHOP Datahop Ltd"
     reverse: "mailgate.syzygy.net"
     country: "GB"
-  - 
+  -
     ip: "195.216.64.144"
     provider: "DATAWAY-AS dataway GmbH"
     reverse: "stargazer.dataway.ch"
     country: "CH"
-  - 
+  -
     ip: "89.199.255.3"
     provider: "DBD-AS DBD Deutsche Breitband Dienste GmbH"
     reverse: "ns.dbd-breitband.de"
     country: "DE"
-  - 
+  -
     ip: "82.143.255.133"
     provider: "DBNET-AS Danish Broadband a/s"
     reverse: "ns.officeline.dk"
     country: "DK"
-  - 
+  -
     ip: "80.191.106.170"
     provider: "DCI-AS Information Technology Company (ITC)"
     reverse: "80.191.106.170"
     country: "IR"
-  - 
+  -
     ip: "80.191.106.129"
     country: "IR"
     reverse: "80.191.106.129"
     provider: "DCI-AS Information Technology Company (ITC)"
-  - 
+  -
     ip: "80.191.92.150"
     country: "IR"
     reverse: "80.191.92.150"
     provider: "DCI-AS Information Technology Company (ITC)"
-  - 
+  -
     ip: "80.191.92.146"
     provider: "DCI-AS Information Technology Company (ITC)"
     reverse: "80.191.92.146"
     country: "IR"
-  - 
+  -
     ip: "80.191.91.19"
     country: "IR"
     reverse: "80.191.91.19"
     provider: "DCI-AS Information Technology Company (ITC)"
-  - 
+  -
     ip: "12.27.222.9"
     provider: "DEKALB - DTC Communications, Inc."
     reverse: "rad2.dtccom.net"
     country: "US"
-  - 
+  -
     ip: "213.137.73.254"
     provider: "DELTATHREE - Deltathree"
     reverse: "ns.deltathree.com"
     country: "US"
-  - 
+  -
     ip: "212.43.68.10"
     country: "DE"
     reverse: "dns-2.witcom.de"
     provider: "DELUNET inexio Informationstechnologie und TelekommunikationKGaA"
-  - 
+  -
     ip: "212.43.89.7"
     provider: "DELUNET inexio Informationstechnologie und TelekommunikationKGaA"
     reverse: "ns01.overturn.de"
     country: "DE"
-  - 
+  -
     ip: "212.43.90.7"
     country: "DE"
     reverse: "ns02.overturn.de"
     provider: "DELUNET inexio Informationstechnologie und TelekommunikationKGaA"
-  - 
+  -
     ip: "8.6.221.128"
     provider: "DESYNC - Desync Networks"
     reverse: "beta.websolutions.net.au"
     country: "US"
-  - 
+  -
     ip: "8.6.221.129"
     country: "US"
     reverse: "8.6.221.129"
     provider: "DESYNC - Desync Networks"
-  - 
+  -
     ip: "131.234.16.15"
     provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
     reverse: "131.234.16.15"
     country: "DE"
-  - 
+  -
     ip: "132.252.150.1"
     country: "DE"
     reverse: "pilz.iem.uni-duisburg-essen.de"
     provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
-  - 
+  -
     ip: "134.91.211.2"
     country: "DE"
     reverse: "ns2.theo-phys.uni-essen.de"
     provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
-  - 
+  -
     ip: "139.30.42.2"
     provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
     reverse: "smaragd.physik1.uni-rostock.de"
     country: "DE"
-  - 
+  -
     ip: "139.30.161.40"
     country: "DE"
     reverse: "nserver161.med.uni-rostock.de"
     provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
-  - 
+  -
     ip: "141.53.8.1"
     provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
     reverse: "dnsp.uni-greifswald.de"
     country: "DE"
-  - 
+  -
     ip: "141.53.8.3"
     country: "DE"
     reverse: "dnss.uni-greifswald.de"
     provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
-  - 
+  -
     ip: "141.56.31.3"
     provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
     reverse: "hp2.rz.htw-dresden.de"
     country: "DE"
-  - 
+  -
     ip: "141.61.1.32"
     country: "DE"
     reverse: "ns1.biochem.mpg.de"
     provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
-  - 
+  -
     ip: "192.54.34.3"
     provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
     reverse: "ns7.bi.fraunhofer.de"
     country: "DE"
-  - 
+  -
     ip: "192.76.157.4"
     provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
     reverse: "statler.rz.hs-wismar.de"
     country: "DE"
-  - 
+  -
     ip: "192.109.44.14"
     provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
     reverse: "poseidon.arb-phys.uni-dortmund.de"
     country: "DE"
-  - 
-    ip: "192.109.44.41"
-    country: "DE"
-    reverse: "perseus.arb-phys.uni-dortmund.de"
-    provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
-  - 
+  -
     ip: "194.95.64.4"
     country: "DE"
     reverse: "ns1.hochschule-bonn-rhein-sieg.de"
     provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
-  - 
+  -
     ip: "194.95.64.5"
     provider: "DFN Verein zur Foerderung eines Deutschen Forschungsnetzes e.V."
     reverse: "ns2.hochschule-bonn-rhein-sieg.de"
     country: "DE"
-  - 
+  -
     ip: "64.193.228.2"
     country: "US"
     reverse: "ns2.digis.net"
     provider: "DIGIS-23205 - JAB Wireless, INC."
-  - 
+  -
     ip: "64.40.72.25"
     country: "US"
     reverse: "dns1.glbgil.grics.net"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
-  - 
+  -
     ip: "64.40.75.40"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
     reverse: "dnsc1-pekn.il.centurylink.net"
     country: "US"
-  - 
+  -
     ip: "64.91.3.46"
     country: "US"
     reverse: "dnsc1-clm.mo.centurylink.net"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
-  - 
+  -
     ip: "64.91.3.60"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
     reverse: "dnsc2-clm.mo.centurylink.net"
     country: "US"
-  - 
+  -
     ip: "64.91.89.2"
     country: "US"
     reverse: "dnsc1-doth.al.centurylink.net"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
-  - 
+  -
     ip: "64.91.92.21"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
     reverse: "dnsc1-pell.al.centurylink.net"
     country: "US"
-  - 
+  -
     ip: "64.91.92.22"
     country: "US"
     reverse: "dnsc2-pell.al.centurylink.net"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
-  - 
+  -
     ip: "66.112.11.87"
     country: "US"
     reverse: "dnsc1-wnvl.mo.centurylink.net"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
-  - 
+  -
     ip: "66.112.11.88"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
     reverse: "dnsc2-wnvl.mo.centurylink.net"
     country: "US"
-  - 
+  -
     ip: "204.9.122.102"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
     reverse: "ns2.digitalteleport.com"
     country: "US"
-  - 
+  -
     ip: "204.9.123.122"
     country: "US"
     reverse: "ns1.digitalteleport.com"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
-  - 
+  -
     ip: "207.230.202.28"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
     reverse: "dnsc1-def.wi.centurylink.net"
     country: "US"
-  - 
+  -
     ip: "207.230.202.29"
     country: "US"
     reverse: "dnsc2-def.wi.centurylink.net"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
-  - 
+  -
     ip: "208.54.220.20"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
     reverse: "dnsc1-jax.ar.centurylink.net"
     country: "US"
-  - 
+  -
     ip: "208.54.220.21"
     country: "US"
     reverse: "dnsc2-jax.ar.centurylink.net"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
-  - 
+  -
     ip: "209.142.182.250"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
     reverse: "dnsc1-vp.la.centurylink.net"
     country: "US"
-  - 
+  -
     ip: "209.206.136.8"
     country: "US"
     reverse: "dnsc1-che.mi.centurylink.net"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
-  - 
+  -
     ip: "209.206.160.253"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
     reverse: "dnsc2-gh.wa.centurylink.net"
     country: "US"
-  - 
+  -
     ip: "209.206.184.250"
     country: "US"
     reverse: "dnsc2-ka.mt.centurylink.net"
     provider: "DIGITAL-TELEPORT - Digital Teleport Inc."
-  - 
+  -
     ip: "213.248.24.25"
     country: "RU"
     reverse: "ns1.oducentr.ru"
     provider: "DINET-AS Digital Networks CJSC"
-  - 
+  -
     ip: "193.162.198.1"
     provider: "DMDATA-AS IBM Denmark ApS"
     reverse: "ns1.dmdata.net"
     country: "DK"
-  - 
+  -
     ip: "81.18.97.50"
     provider: "DOKUMENTA-AS1 Dokumenta AG"
     reverse: "ns02.dokumenta.net"
     country: "DE"
-  - 
+  -
     ip: "93.90.82.50"
     provider: "DONTECHSVYAZ Dontechsvyaz, private joint stock company"
     reverse: "donnetwork.ru"
     country: "RU"
-  - 
+  -
     ip: "91.194.211.134"
     country: "PL"
     reverse: "ip-91.194.211.134.doskomp.lodz.pl"
     provider: "DOSKOMP OPW DOSKOMP Sp.z.o.o"
-  - 
+  -
     ip: "196.41.0.10"
     country: "ZA"
     reverse: "dnscache1.datapro.co.za"
     provider: "DPBOL"
-  - 
+  -
     ip: "196.41.0.11"
     provider: "DPBOL"
     reverse: "dnscache2.datapro.co.za"
     country: "ZA"
-  - 
+  -
     ip: "195.69.126.2"
     provider: "DRQ-AS Asseco Poland S.A."
     reverse: "dnsb.drq.pl"
     country: "PL"
-  - 
+  -
     ip: "202.27.77.100"
     provider: "DSLAK-AS-AP Internet access for Datacom Systems Auckland"
     reverse: "ns1.datacom.co.nz"
     country: "NZ"
-  - 
+  -
     ip: "66.51.205.100"
     provider: "DSLEXTREME - DSL Extreme"
     reverse: "dns1.dslextreme.com"
     country: "US"
-  - 
+  -
     ip: "66.51.206.100"
     country: "US"
     reverse: "dns2.dslextreme.com"
     provider: "DSLEXTREME - DSL Extreme"
-  - 
+  -
     ip: "62.159.92.10"
     provider: "DTAG Deutsche Telekom AG"
     reverse: "nsi01.netzstation.net"
     country: "DE"
-  - 
+  -
     ip: "80.146.190.1"
     provider: "DTAG Deutsche Telekom AG"
     reverse: "ns.ranet.de"
     country: "DE"
-  - 
+  -
     ip: "193.22.110.251"
     provider: "DTAG Deutsche Telekom AG"
     reverse: "integral.igepa-its.de"
     country: "DE"
-  - 
+  -
     ip: "193.25.208.49"
     provider: "DTAG Deutsche Telekom AG"
     reverse: "rs49.wuh-lengerich.de"
     country: "DE"
-  - 
+  -
     ip: "193.41.10.1"
     provider: "DTAG Deutsche Telekom AG"
     reverse: "ns1.wds.net"
     country: "DE"
-  - 
+  -
     ip: "193.188.196.250"
     provider: "DTAG Deutsche Telekom AG"
     reverse: "uoproxy.uniorg.de"
     country: "DE"
-  - 
+  -
     ip: "194.25.0.52"
     country: "DE"
     reverse: "resolv-l.dtag.de"
     provider: "DTAG Deutsche Telekom AG"
-  - 
+  -
     ip: "194.25.0.60"
     provider: "DTAG Deutsche Telekom AG"
     reverse: "resolv-h.dtag.de"
     country: "DE"
-  - 
+  -
     ip: "194.25.0.68"
     country: "DE"
     reverse: "resolv-f.dtag.de"
     provider: "DTAG Deutsche Telekom AG"
-  - 
+  -
     ip: "194.113.60.2"
     country: "DE"
     reverse: "ns.canon-giessen.de"
     provider: "DTAG Deutsche Telekom AG"
-  - 
+  -
     ip: "194.113.160.68"
     provider: "DTAG Deutsche Telekom AG"
     reverse: "mailhub.kvs-sachsen.de"
     country: "DE"
-  - 
+  -
     ip: "195.145.22.37"
     provider: "DTAG Deutsche Telekom AG"
     reverse: "vwdednsmw61.vorwerk.de"
     country: "DE"
-  - 
+  -
     ip: "195.243.214.4"
     country: "DE"
     reverse: "195.243.214.4"
     provider: "DTAG Deutsche Telekom AG"
-  - 
+  -
     ip: "217.6.0.99"
     provider: "DTAG Deutsche Telekom AG"
     reverse: "pns.net-art.net"
     country: "DE"
-  - 
+  -
     ip: "212.125.57.102"
     country: "DE"
     reverse: "ns02.systemhaus.net"
     provider: "DTMS-AS dtms Deutsche Telefon- und Marketing Service GmbH"
-  - 
+  -
     ip: "193.243.128.91"
     provider: "DXI-SOL-CORE MoneyAM Ltd"
     reverse: "ns1.moneyam.com"
     country: "GB"
-  - 
+  -
     ip: "198.153.192.1"
     country: "US"
     reverse: "198.153.192.1"
     provider: "DYNDNS - Dynamic Network Services, Inc."
-  - 
+  -
     ip: "198.153.194.1"
     country: "US"
     reverse: "198.153.194.1"
     provider: "DYNDNS - Dynamic Network Services, Inc."
-  - 
+  -
     ip: "198.153.192.40"
     country: "US"
     reverse: "198.153.192.40"
     provider: "DYNDNS - Dynamic Network Services, Inc."
-  - 
+  -
     ip: "198.153.194.40"
     provider: "DYNDNS - Dynamic Network Services, Inc."
     reverse: "198.153.194.40"
     country: "US"
-  - 
+  -
     ip: "216.146.35.35"
     provider: "DYNDNS - Dynamic Network Services, Inc."
     reverse: "resolver1.dyndnsinternetguide.com"
     country: "US"
-  - 
+  -
     ip: "216.146.36.36"
     country: "US"
     reverse: "resolver2.dyndnsinternetguide.com"
     provider: "DYNDNS - Dynamic Network Services, Inc."
-  - 
+  -
     ip: "198.153.192.60"
     provider: "DYNDNS - Dynamic Network Services, Inc."
     reverse: "198.153.192.60"
     country: "US"
-  - 
+  -
     ip: "198.153.194.50"
     country: "US"
     reverse: "198.153.194.50"
     provider: "DYNDNS - Dynamic Network Services, Inc."
-  - 
+  -
     ip: "198.153.194.60"
     provider: "DYNDNS - Dynamic Network Services, Inc."
     reverse: "198.153.194.60"
     country: "US"
-  - 
+  -
     ip: "195.170.32.18"
     country: "RU"
     reverse: "ns.east.ru"
     provider: "EAST-AS East Telecom ISP Autonomous system"
-  - 
+  -
     ip: "195.170.55.1"
     provider: "EAST-AS East Telecom ISP Autonomous system"
     reverse: "ns2.east.ru"
     country: "RU"
-  - 
+  -
     ip: "64.68.200.200"
     provider: "EASYDNS EasyDNS Technologies, Inc."
     reverse: "cache2.dnsresolvers.com"
     country: "CA"
-  - 
+  -
     ip: "193.34.88.202"
     country: "BE"
     reverse: "ns1.s03.hostingcentrale.be"
     provider: "EASYHOST-COLO-AS Easyhost BVBA"
-  - 
+  -
     ip: "193.34.88.203"
     provider: "EASYHOST-COLO-AS Easyhost BVBA"
     reverse: "ns2.s03.hostingcentrale.be"
     country: "BE"
-  - 
+  -
     ip: "193.34.90.156"
     country: "BE"
     reverse: "ns1.domeincentrale.be"
     provider: "EASYHOST-COLO-AS Easyhost BVBA"
-  - 
+  -
     ip: "212.135.191.52"
     provider: "EASYNET Easynet Global Services"
     reverse: "ns1.fmware.net"
     country: "EU"
-  - 
+  -
     ip: "78.152.23.67"
     provider: "EAW-AS East & West Sp. z o.o."
     reverse: "dns2.eastwest.com.pl"
     country: "PL"
-  - 
+  -
     ip: "193.16.3.11"
     provider: "ECCE-TERRAM-DE ECCE TERRAM Internet Services GmbH"
     reverse: "ns.ecce-terram.de"
     country: "DE"
-  - 
+  -
     ip: "203.22.70.7"
     country: "NZ"
     reverse: "mail-commerce.ecn.net.au"
     provider: "ECN-AS-AP ECN Internet"
-  - 
+  -
     ip: "41.221.1.66"
     country: "ZA"
     reverse: "41.221.1.66"
     provider: "ECN-AS1"
-  - 
+  -
     ip: "41.221.5.170"
     provider: "ECN-AS1"
     reverse: "41.221.5.170"
     country: "ZA"
-  - 
+  -
     ip: "41.221.5.172"
     country: "ZA"
     reverse: "41.221.5.172"
     provider: "ECN-AS1"
-  - 
+  -
     ip: "79.135.230.2"
     provider: "ECONOTEL-AS CJSC _Econotel_"
     reverse: "2.230.135.79.in-addr.arpa"
     country: "RU"
-  - 
+  -
     ip: "212.204.49.83"
     provider: "EDISCOM e.discom Telekommunikation GmbH"
     reverse: "ns2.bytecamp.net"
     country: "DE"
-  - 
+  -
     ip: "212.204.60.4"
     country: "DE"
     reverse: "ns1.bytecamp.net"
     provider: "EDISCOM e.discom Telekommunikation GmbH"
-  - 
+  -
     ip: "203.123.94.40"
     country: "AU"
     reverse: "eth1-5.ns-container.mel.dft.com.au"
     provider: "EFTEL-AS-AP Eftel Limited."
-  - 
+  -
     ip: "216.235.1.3"
     country: "CA"
     reverse: "ns2.dm.egate.net"
     provider: "EGATE-NETWORKS E-Gate Networks"
-  - 
+  -
     ip: "80.66.0.30"
     country: "DE"
     reverse: "ns.eggenet.de"
     provider: "EGGENET EWE TEL GmbH"
-  - 
+  -
     ip: "80.66.1.42"
     provider: "EGGENET EWE TEL GmbH"
     reverse: "ns2.eggenet.de"
     country: "DE"
-  - 
+  -
     ip: "212.30.252.1"
     provider: "EJS-HYSING-HF Advania hf."
     reverse: "ns1.skrin.is"
     country: "IS"
-  - 
+  -
     ip: "95.181.47.114"
     country: "RU"
     reverse: "95-181-47-114.goodline.info"
     provider: "ELIGHT-AS E-Light-Telecom"
-  - 
+  -
     ip: "8.26.56.26"
     country: "US"
     reverse: "ns1.recursive.dns.com"
     provider: "ELV-ANYCAST-NET ANYCAST-AS"
-  - 
+  -
     ip: "8.20.247.20"
     provider: "ELV-ANYCAST-NET ANYCAST-AS"
     reverse: "ns2.recursive.dns.com"
     country: "US"
-  - 
+  -
     ip: "207.14.235.234"
     provider: "EMBARQ-RCMT - Embarq Corporation"
     reverse: "dns-auth-3.embarqservices.net"
     country: "US"
-  - 
+  -
     ip: "195.218.123.128"
     country: "IE"
     reverse: "195.218.123.128"
     provider: "ENERGIS-IRELAND Energis Ireland Backbone Network"
-  - 
+  -
     ip: "195.238.246.238"
     country: "RU"
     reverse: "ns.entc.ru"
     provider: "ENERGY-AS JSC Energy"
-  - 
+  -
     ip: "87.241.223.68"
     provider: "ENFORTA-AS Enforta Autonomous System"
     reverse: "ns1.enforta.com"
     country: "RU"
-  - 
+  -
     ip: "192.188.199.6"
     provider: "EPFL-AS - Enoch-Pratt Free Library"
     reverse: "ns1.pratt.lib.md.us"
     country: "US"
-  - 
+  -
     ip: "163.5.255.1"
     country: "FR"
     reverse: "ns-1.ig-iit.com"
     provider: "EPITECH Epitech"
-  - 
+  -
     ip: "163.5.255.2"
     provider: "EPITECH Epitech"
     reverse: "ns-2.ig-iit.com"
     country: "FR"
-  - 
+  -
     ip: "95.154.128.32"
     country: "RU"
     reverse: "rejector.ru"
     provider: "EPL-AS Production co-operative Economic-legal laboratory"
-  - 
+  -
     ip: "62.182.231.189"
     country: "PL"
     reverse: "dns1.ertel.com.pl"
     provider: "ERTEL-AS Ertel sp. z o.o."
-  - 
+  -
     ip: "62.182.231.243"
     provider: "ERTEL-AS Ertel sp. z o.o."
     reverse: "dns.ertel.com.pl"
     country: "PL"
-  - 
+  -
     ip: "91.144.248.227"
     provider: "ERTELE-AS Verdo Tele A/S"
     reverse: "ns3.wwi.as"
     country: "DK"
-  - 
+  -
     ip: "125.219.48.8"
     provider: "ERX-CERNET-BKB China Education and Research Network Center"
     reverse: "125.219.48.8"
     country: "CN"
-  - 
+  -
     ip: "210.34.0.18"
     provider: "ERX-CERNET-BKB China Education and Research Network Center"
     reverse: "dns.xmu.edu.cn"
     country: "CN"
-  - 
+  -
     ip: "165.21.83.88"
     provider: "ERX-SINGNET SingNet"
     reverse: "dnscache1.singnet.com.sg"
     country: "SG"
-  - 
+  -
     ip: "165.21.100.88"
     country: "SG"
     reverse: "dnscache2.singnet.com.sg"
     provider: "ERX-SINGNET SingNet"
-  - 
+  -
     ip: "208.38.164.130"
     provider: "ESC-TPA-CW-AP - E Solutions Corporation"
     reverse: "ns1.esnet.com"
     country: "US"
-  - 
+  -
     ip: "203.25.185.119"
     provider: "ESCAPE-NET-AS Escape.net"
     reverse: "srv-kw-rb2.esc.net.au"
     country: "AU"
-  - 
+  -
     ip: "216.8.209.88"
     country: "US"
     reverse: "ns3.etcdns.net"
     provider: "ETC-60-AS - ENHANCED TELECOMMUNICATIONS CORP."
-  - 
+  -
     ip: "194.145.204.20"
     provider: "ETELKO-AS e-Telko Sp. z o.o."
     reverse: "dns.etelko.pl"
     country: "PL"
-  - 
+  -
     ip: "216.224.112.12"
     provider: "ETHRN1 - Ethr.Net LLC"
     reverse: "j112-12.sjc1.ethr.net"
     country: "US"
-  - 
+  -
     ip: "212.71.98.250"
     provider: "EVERYWARE-NET EveryWare LTD."
     reverse: "ns2.everyware.ch"
     country: "CH"
-  - 
+  -
     ip: "220.233.0.4"
     country: "AU"
     reverse: "kolanut2-dns.exetel.com.au"
     provider: "EXETEL-AS-AP Exetel Pty Ltd"
-  - 
+  -
     ip: "220.233.0.3"
     country: "AU"
     reverse: "kolanut-dns.exetel.com.au"
     provider: "EXETEL-AS-AP Exetel Pty Ltd"
-  - 
+  -
     ip: "220.233.0.1"
     provider: "EXETEL-AS-AP Exetel Pty Ltd"
     reverse: "ns1.exetel.com.au"
     country: "AU"
-  - 
+  -
     ip: "85.115.224.18"
     country: "RU"
     reverse: "fortress.extel-gsm.com"
     provider: "EXTEL-AS OJSC _VimpelCom_"
-  - 
+  -
     ip: "199.52.8.42"
     country: "US"
     reverse: "agdcns1.ey.com"
     provider: "EY-AS - Ernst & Young LLP"
-  - 
+  -
     ip: "69.24.112.10"
     country: "US"
     reverse: "ns2.ffni.com"
     provider: "FAIRNET-LLC - FAIRNET LLC"
-  - 
+  -
     ip: "77.68.37.80"
     provider: "FASTHOSTS-INTERNET Fasthosts Internet Ltd. Gloucester, UK."
     reverse: "ns1.tuscanred.net"
     country: "GB"
-  - 
+  -
     ip: "77.68.39.92"
     country: "GB"
     reverse: "ns1.pollab.com"
     provider: "FASTHOSTS-INTERNET Fasthosts Internet Ltd. Gloucester, UK."
-  - 
+  -
     ip: "213.171.220.215"
     provider: "FASTHOSTS-INTERNET Fasthosts Internet Ltd. Gloucester, UK."
     reverse: "server11.gifford.co.uk"
     country: "GB"
-  - 
+  -
     ip: "217.174.252.65"
     provider: "FASTHOSTS-INTERNET Fasthosts Internet Ltd. Gloucester, UK."
     reverse: "ns2.meridian-micro.co.uk"
     country: "GB"
-  - 
+  -
     ip: "217.174.252.116"
     country: "GB"
     reverse: "ns1.meridian-micro.co.uk"
     provider: "FASTHOSTS-INTERNET Fasthosts Internet Ltd. Gloucester, UK."
-  - 
+  -
     ip: "216.38.128.2"
     country: "US"
     reverse: "ns1.fastmetrics.com"
     provider: "FASTMETRICS - Fastmetrics"
-  - 
+  -
     ip: "212.42.165.37"
     provider: "FASTNETUK FastNet International Ltd"
     reverse: "ns0.friday-net.co.uk"
     country: "GB"
-  - 
+  -
     ip: "83.69.112.186"
     provider: "FATUM-AS LLC _Fatum-3_"
     reverse: "bilag.snow-kazan.ru"
     country: "RU"
-  - 
+  -
     ip: "182.163.74.213"
     country: "JP"
     reverse: "v-182-163-74-213.ub-freebit.net"
     provider: "FBDC FreeBit Co.,Ltd."
-  - 
+  -
     ip: "210.143.144.11"
     provider: "FBDC FreeBit Co.,Ltd."
     reverse: "ns1.freebit.net"
     country: "JP"
-  - 
+  -
     ip: "210.143.144.12"
     country: "JP"
     reverse: "ns2.freebit.net"
     provider: "FBDC FreeBit Co.,Ltd."
-  - 
+  -
     ip: "219.99.80.251"
     provider: "FBDC FreeBit Co.,Ltd."
     reverse: "ns3.freebit.net"
     country: "JP"
-  - 
+  -
     ip: "76.73.18.50"
     provider: "FDCSERVERS - FDCservers.net"
     reverse: "76.73.18.50"
     country: "US"
-  - 
+  -
     ip: "204.45.18.18"
     provider: "FDCSERVERS - FDCservers.net"
     reverse: "204.45.18.18"
     country: "US"
-  - 
+  -
     ip: "204.45.18.26"
     country: "US"
     reverse: "204.45.18.26"
     provider: "FDCSERVERS - FDCservers.net"
-  - 
+  -
     ip: "84.241.100.31"
     country: "CH"
     reverse: "ns1.comtronic.ch"
     provider: "FINECOM Finecom Telecommunications AG"
-  - 
+  -
     ip: "212.60.63.246"
     country: "CH"
     reverse: "ns3.fcom.ch"
     provider: "FINECOM Finecom Telecommunications AG"
-  - 
+  -
     ip: "62.140.230.9"
     provider: "FIORD-AS JSC _TRC FIORD_"
     reverse: "ns1.fiord.ru"
     country: "RU"
-  - 
+  -
     ip: "64.126.133.1"
     country: "US"
     reverse: "ns.fsr.com"
     provider: "FIRST-STEP - FIRST STEP INTERNET, LLC"
-  - 
+  -
     ip: "64.126.133.2"
     provider: "FIRST-STEP - FIRST STEP INTERNET, LLC"
     reverse: "ns3.fsr.com"
     country: "US"
-  - 
+  -
     ip: "64.126.155.1"
     country: "US"
     reverse: "ns2.fsr.com"
     provider: "FIRST-STEP - FIRST STEP INTERNET, LLC"
-  - 
+  -
     ip: "91.135.230.231"
     provider: "FIRSTSERV-AS Firstserv Limited"
     reverse: "dns1.lede.co.uk"
     country: "GB"
-  - 
+  -
     ip: "131.94.7.220"
     provider: "FIU - Florida International University"
     reverse: "ns1.fiu.edu"
     country: "US"
-  - 
+  -
     ip: "131.94.205.10"
     country: "US"
     reverse: "ns.fiu.edu"
     provider: "FIU - Florida International University"
-  - 
+  -
     ip: "131.94.226.10"
     provider: "FIU - Florida International University"
     reverse: "ns3.fiu.edu"
     country: "US"
-  - 
+  -
     ip: "81.92.96.22"
     provider: "FLASHCABLE GIB-Solutions AG"
     reverse: "ns2.flashcable.ch"
     country: "CH"
-  - 
+  -
     ip: "81.92.97.12"
     country: "CH"
     reverse: "ns1.flashcable.ch"
     provider: "FLASHCABLE GIB-Solutions AG"
-  - 
+  -
     ip: "217.144.144.11"
     country: "GB"
     reverse: "ns1.fmn.uk.net"
     provider: "FMN Fusion Media Networks Ltd"
-  - 
+  -
     ip: "217.144.144.211"
     provider: "FMN Fusion Media Networks Ltd"
     reverse: "ns2.fmn.uk.net"
     country: "GB"
-  - 
+  -
     ip: "77.242.226.226"
     provider: "FONE-ASN Hawe Telekom Sp. z.o.o."
     reverse: "ns1.pbthawe.eu"
     country: "PL"
-  - 
+  -
     ip: "77.242.229.254"
     country: "PL"
     reverse: "ns1.coel-network.net.229.242.77.in-addr.arpa"
     provider: "FONE-ASN Hawe Telekom Sp. z.o.o."
-  - 
+  -
     ip: "189.90.16.20"
     country: "BR"
     reverse: "jangada.fortalnet.com.br"
     provider: "FORTALNET BUREAU DE COMERCIO E SERVICOS LTDA"
-  - 
+  -
     ip: "69.57.163.124"
     country: "US"
     reverse: "ns1.1timesolutions.biz"
     provider: "FORTRESSITX - FortressITX"
-  - 
+  -
     ip: "79.99.66.3"
     provider: "FOURD-AS 4D Data Centres Ltd"
     reverse: "ns2.truedns.co.uk"
     country: "GB"
-  - 
+  -
     ip: "193.48.57.34"
     provider: "FR-RENATER Reseau National de telecommunications pour la Technologie"
     reverse: "pevele.escaut.net"
     country: "FR"
-  - 
+  -
     ip: "193.48.71.3"
     country: "FR"
     reverse: "zorn.ceremade.dauphine.fr"
     provider: "FR-RENATER Reseau National de telecommunications pour la Technologie"
-  - 
+  -
     ip: "193.49.159.226"
     provider: "FR-RENATER Reseau National de telecommunications pour la Technologie"
     reverse: "lisbonne-pra.renater.fr"
     country: "FR"
-  - 
+  -
     ip: "193.51.104.7"
     country: "FR"
     reverse: "seven.ihes.fr"
     provider: "FR-RENATER Reseau National de telecommunications pour la Technologie"
-  - 
+  -
     ip: "193.51.206.132"
     provider: "FR-RENATER Reseau National de telecommunications pour la Technologie"
     reverse: "mx1.noc.renater.fr"
     country: "FR"
-  - 
+  -
     ip: "193.52.218.19"
     country: "FR"
     reverse: "ns1.syrhano.net"
     provider: "FR-RENATER Reseau National de telecommunications pour la Technologie"
-  - 
+  -
     ip: "195.98.236.11"
     country: "FR"
     reverse: "rediufm.amiens.iufm.fr"
     provider: "FR-RENATER Reseau National de telecommunications pour la Technologie"
-  - 
+  -
     ip: "195.221.20.10"
     provider: "FR-RENATER Reseau National de telecommunications pour la Technologie"
     reverse: "ns.crihan.fr"
     country: "FR"
-  - 
+  -
     ip: "162.38.221.50"
     provider: "FR-RENATER-HDMON Reseau metropolitain de Montpellier HDMON"
     reverse: "mail.iutmontp.univ-montp2.fr"
     country: "EU"
-  - 
+  -
     ip: "134.157.90.3"
     provider: "FR-U-JUSSIEU-PARIS"
     reverse: "gulliver.lct.jussieu.fr"
     country: "EU"
-  - 
+  -
     ip: "137.251.36.6"
     country: "DE"
     reverse: "mailer1.iao.fhg.de"
     provider: "FRAUNHOFER-CLUSTER-BW Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V."
-  - 
+  -
     ip: "94.232.40.16"
     country: "RU"
     reverse: "mx2.sms-hit.ru"
     provider: "FREECASH-AS LLC _Svobodnaya kassa_"
-  - 
+  -
     ip: "216.17.128.1"
     provider: "FRII - Front Range Internet Inc."
     reverse: "ns1.frii.com"
     country: "US"
-  - 
+  -
     ip: "216.17.128.2"
     country: "US"
     reverse: "ns2.frii.com"
     provider: "FRII - Front Range Internet Inc."
-  - 
+  -
     ip: "65.73.172.4"
     provider: "FRONTIER-AND-CITIZENS - Frontier Communications of America, Inc."
     reverse: "resolve01.leol.pa.frontiernet.net"
     country: "US"
-  - 
+  -
     ip: "170.215.126.3"
     country: "US"
     reverse: "resolve01.ckvl.tn.frontiernet.net"
     provider: "FRONTIER-AND-CITIZENS - Frontier Communications of America, Inc."
-  - 
+  -
     ip: "170.215.132.4"
     provider: "FRONTIER-AND-CITIZENS - Frontier Communications of America, Inc."
     reverse: "resolve01.chtw.wv.frontiernet.net"
     country: "US"
-  - 
+  -
     ip: "170.215.184.3"
     country: "US"
     reverse: "resolve01.blfd.wv.frontiernet.net"
     provider: "FRONTIER-AND-CITIZENS - Frontier Communications of America, Inc."
-  - 
+  -
     ip: "170.215.255.114"
     provider: "FRONTIER-AND-CITIZENS - Frontier Communications of America, Inc."
     reverse: "resolve01.mdtw.ny.frontiernet.net"
     country: "US"
-  - 
+  -
     ip: "216.67.192.3"
     provider: "FRONTIER-AND-CITIZENS - Frontier Communications of America, Inc."
     reverse: "resolve01.kgmn.az.frontiernet.net"
     country: "US"
-  - 
+  -
     ip: "199.224.127.78"
     provider: "FRONTIER-EPIX - Frontier Communications of America, Inc."
     reverse: "resolve-127-78.dlls.pa.frontiernet.net"
     country: "US"
-  - 
+  -
     ip: "66.133.150.12"
     provider: "FRONTIER-FRTR - Frontier Communications of America, Inc."
     reverse: "resolve.lkvl.mn.frontiernet.net"
     country: "US"
-  - 
+  -
     ip: "66.133.170.2"
     country: "US"
     reverse: "resolve.roch.ny.frontiernet.net"
     provider: "FRONTIER-FRTR - Frontier Communications of America, Inc."
-  - 
+  -
     ip: "66.133.191.35"
     provider: "FRONTIER-FRTR - Frontier Communications of America, Inc."
     reverse: "old-resolve01.lkvl.mn.frontiernet.net"
     country: "US"
-  - 
+  -
     ip: "64.147.188.6"
     country: "US"
     reverse: "ns2.eff.org"
     provider: "FUSIONSTORM-GNI - FusionStorm"
-  - 
+  -
     ip: "64.147.188.9"
     provider: "FUSIONSTORM-GNI - FusionStorm"
     reverse: "ns1.eff.org"
     country: "US"
-  - 
+  -
     ip: "199.201.159.5"
     country: "US"
     reverse: "ns2.jlc.net"
     provider: "G4-COMMUNICATIONS - Metro2000, Inc."
-  - 
+  -
     ip: "67.216.35.25"
     country: "US"
     reverse: "authdns01.gafachi.com"
     provider: "GAFACHI-AS - Gafachi, Inc."
-  - 
+  -
     ip: "84.205.31.2"
     provider: "GAWEX-AS Gawex Media sp. z o. o."
     reverse: "dns.gawex.pl"
     country: "PL"
-  - 
+  -
     ip: "64.212.106.84"
     country: "US"
     reverse: "dns1.jfk.gblx.net"
     provider: "GBLX Global Crossing Ltd."
-  - 
+  -
     ip: "64.212.106.85"
     provider: "GBLX Global Crossing Ltd."
     reverse: "dns2.jfk.gblx.net"
     country: "US"
-  - 
+  -
     ip: "64.215.98.148"
     country: "US"
     reverse: "dns1.lon.gblx.net"
     provider: "GBLX Global Crossing Ltd."
-  - 
+  -
     ip: "67.17.215.133"
     provider: "GBLX Global Crossing Ltd."
     reverse: "dns2.snv.gblx.net"
     country: "US"
-  - 
+  -
     ip: "195.166.13.4"
     country: "US"
     reverse: "dns0.ns.uk.quza.net"
     provider: "GBLX Global Crossing Ltd."
-  - 
+  -
     ip: "209.130.136.2"
     provider: "GBLX Global Crossing Ltd."
     reverse: "dns1.roc.gblx.net"
     country: "US"
-  - 
+  -
     ip: "82.138.243.24"
     country: "BE"
     reverse: "ns2.oh2.co.uk"
     provider: "GBXS-AS M247 Ltd"
-  - 
+  -
     ip: "194.145.240.6"
     provider: "GBXS-AS M247 Ltd"
     reverse: "ns1.fivestardns.com"
     country: "BE"
-  - 
+  -
     ip: "194.145.241.6"
     country: "BE"
     reverse: "ns2.fivestardns.com"
     provider: "GBXS-AS M247 Ltd"
-  - 
+  -
     ip: "195.242.214.81"
     country: "BE"
     reverse: "ns1.eyotahosts.net"
     provider: "GBXS-AS M247 Ltd"
-  - 
+  -
     ip: "195.242.214.82"
     provider: "GBXS-AS M247 Ltd"
     reverse: "ns2.eyotahosts.net"
     country: "BE"
-  - 
+  -
     ip: "24.237.132.5"
     provider: "GCI - GENERAL COMMUNICATION, INC."
     reverse: "24-237-132-5.anc.clearwire-dns.net"
     country: "US"
-  - 
+  -
     ip: "209.165.131.12"
     country: "US"
     reverse: "vcns-1.gci.net"
     provider: "GCI - GENERAL COMMUNICATION, INC."
-  - 
+  -
     ip: "209.165.131.13"
     provider: "GCI - GENERAL COMMUNICATION, INC."
     reverse: "vcns-2.gci.net"
     country: "US"
-  - 
+  -
     ip: "195.36.75.21"
     provider: "GECITS-EU Computacenter AG & Co. oHG"
     reverse: "ns1.computacenter.de"
     country: "DE"
-  - 
+  -
     ip: "195.36.93.21"
     country: "DE"
     reverse: "ns2.computacenter.de"
     provider: "GECITS-EU Computacenter AG & Co. oHG"
-  - 
+  -
     ip: "217.10.80.100"
     provider: "GEDAS-AS gedas Iberia S.A."
     reverse: "ns1.gedas.es"
     country: "ES"
-  - 
+  -
     ip: "217.10.81.100"
     country: "ES"
     reverse: "ns2.gedas.es"
     provider: "GEDAS-AS gedas Iberia S.A."
-  - 
+  -
     ip: "139.1.17.16"
     provider: "GEDAS-DE-AS operational services GmbH & Co. KG"
     reverse: "ns1.gedas.de"
     country: "DE"
-  - 
+  -
     ip: "139.1.144.14"
     country: "DE"
     reverse: "139.1.144.14"
     provider: "GEDAS-DE-AS operational services GmbH & Co. KG"
-  - 
+  -
     ip: "193.41.240.33"
     country: "ES"
     reverse: "ns01.genetsis.com"
     provider: "GENETSIS Genetsis Internet Partners"
-  - 
+  -
     ip: "81.222.113.130"
     country: "RU"
     reverse: "ns.gtss.ru"
     provider: "GEOCOMMUNICATIONS-AS OOO GeoTelecommunications"
-  - 
+  -
     ip: "63.246.63.142"
     provider: "GEUS-CABLE-INTERNET - GEUS"
     reverse: "cache1.geusnet.com"
     country: "US"
-  - 
+  -
     ip: "193.110.205.2"
     provider: "GIEPA-ASN Giegerich & Partner GmbH"
     reverse: "ns.giepa.de"
     country: "DE"
-  - 
+  -
     ip: "193.110.207.5"
     country: "DE"
     reverse: "ns2.giepa.de"
     provider: "GIEPA-ASN Giegerich & Partner GmbH"
-  - 
+  -
     ip: "80.67.169.12"
     provider: "GITOYEN-MAIN-AS Association _Gitoyen_"
     reverse: "ns0.fdn.fr"
     country: "FR"
-  - 
+  -
     ip: "80.67.169.40"
     country: "FR"
     reverse: "ns1.fdn.org"
     provider: "GITOYEN-MAIN-AS Association _Gitoyen_"
-  - 
+  -
     ip: "217.64.163.1"
     provider: "GLOBALACCESS Global Access Internet Services GmbH"
     reverse: "ns1.global.de"
     country: "DE"
-  - 
+  -
     ip: "217.64.167.1"
     country: "DE"
     reverse: "ns2.global.de"
     provider: "GLOBALACCESS Global Access Internet Services GmbH"
-  - 
+  -
     ip: "217.194.64.94"
     country: "DE"
     reverse: "ns.ganag.com"
     provider: "GLOBALAIRNETWORK-AS The Cloud Networks Germany GmbH"
-  - 
+  -
     ip: "217.194.65.7"
     provider: "GLOBALAIRNETWORK-AS The Cloud Networks Germany GmbH"
     reverse: "ns2.ganag.com"
     country: "DE"
-  - 
+  -
     ip: "203.89.226.24"
     provider: "GLOBALCENTER-AU Datacom Victoria"
     reverse: "rbs1.globalcenter.net.au"
     country: "AU"
-  - 
+  -
     ip: "203.89.226.26"
     country: "AU"
     reverse: "mdbs2.globalcenter.net.au"
     provider: "GLOBALCENTER-AU Datacom Victoria"
-  - 
+  -
     ip: "193.254.212.22"
     provider: "GLOBALNOC-AS Averbo GmbH"
     reverse: "ns1.v-ns.de"
     country: "DE"
-  - 
+  -
     ip: "195.114.98.101"
     country: "DE"
     reverse: "dns1.rootdns.de"
     provider: "GLOBALNOC-AS Averbo GmbH"
-  - 
+  -
     ip: "195.114.99.101"
     provider: "GLOBALNOC-AS Averbo GmbH"
     reverse: "dns2.rootdns.de"
     country: "DE"
-  - 
+  -
     ip: "216.147.131.34"
     provider: "GLOBECOMM-11300 - Globecomm Services Maryland LLC"
     reverse: "ns2.globalsat.net"
     country: "US"
-  - 
+  -
     ip: "69.63.44.108"
     country: "CA"
     reverse: "dnscache4.execulink.net"
     provider: "GOLDEN - Golden Triangle On Line"
-  - 
+  -
     ip: "209.239.11.98"
     provider: "GOLDEN - Golden Triangle On Line"
     reverse: "ns2.execulink.com"
     country: "CA"
-  - 
+  -
     ip: "8.8.8.8"
     country: "US"
     reverse: "google-public-dns-a.google.com"
     provider: "GOOGLE - Google Inc."
-  - 
+  -
     ip: "8.8.4.4"
     country: "US"
     reverse: "google-public-dns-b.google.com"
     provider: "GOOGLE - Google Inc."
-  - 
+  -
     ip: "194.63.237.4"
     provider: "GR-EDUNET Greek High-School Internet Network"
     reverse: "nic.thess.sch.gr"
     country: "GR"
-  - 
+  -
     ip: "194.63.239.164"
     country: "GR"
     reverse: "nic.att.sch.gr"
     provider: "GR-EDUNET Greek High-School Internet Network"
-  - 
+  -
     ip: "193.218.124.12"
     provider: "GR-NET Greek Research and Technology Network S.A"
     reverse: "solon.elot.gr"
     country: "GR"
-  - 
+  -
     ip: "194.177.218.25"
     provider: "GR-NET Greek Research and Technology Network S.A"
     reverse: "noc.panteion.gr"
     country: "GR"
-  - 
+  -
     ip: "195.251.98.2"
     provider: "GR-NET Greek Research and Technology Network S.A"
     reverse: "blue.snd.edu.gr"
     country: "GR"
-  - 
+  -
     ip: "195.251.119.23"
     country: "GR"
     reverse: "ns2.rae.gr"
     provider: "GR-NET Greek Research and Technology Network S.A"
-  - 
+  -
     ip: "195.251.123.232"
     provider: "GR-NET Greek Research and Technology Network S.A"
     reverse: "aetos.it.teithe.gr"
     country: "GR"
-  - 
+  -
     ip: "195.251.124.68"
     country: "GR"
     reverse: "pinios.teilar.gr"
     provider: "GR-NET Greek Research and Technology Network S.A"
-  - 
+  -
     ip: "80.64.32.2"
     country: "ES"
     reverse: "ns1.grn.es"
     provider: "GRN-AS GRN Network"
-  - 
+  -
     ip: "212.4.96.22"
     provider: "GRUPALIA-AS Grupalia Internet S.A."
     reverse: "ns1.gnet.es"
     country: "ES"
-  - 
+  -
     ip: "64.187.29.134"
     provider: "GT-BELL - Bell Canada"
     reverse: "h64-187-29-134.gtcust.grouptelecom.net"
     country: "CA"
-  - 
+  -
     ip: "109.69.8.51"
     provider: "GUIFINET-AS Fundacio Privada per a la Xarxa Lliure, Oberta i Neutral, guifi.net"
     reverse: "ns.servidordenoms.cat"
     country: "ES"
-  - 
+  -
     ip: "109.69.8.34"
     provider: "GUIFINET-AS Fundacio Privada per a la Xarxa Lliure, Oberta i Neutral, guifi.net"
     reverse: "109-69-8-34-codigosur.ip4.guifi.net"
     country: "ES"
-  - 
+  -
     ip: "69.85.64.28"
     provider: "GVII - Grand Valley Internet"
     reverse: "ns1.gvii.net"
     country: "US"
-  - 
+  -
     ip: "195.182.9.35"
     country: "PL"
     reverse: "dns1.um.wroc.pl"
     provider: "GW-AS Gmina Wroclaw"
-  - 
+  -
     ip: "94.101.214.180"
     provider: "GlobalConnect a/s"
     reverse: "ns4.wwi.eu"
     country: "DK"
-  - 
+  -
     ip: "62.109.123.6"
     provider: "HANSENET Telefonica Germany GmbH & Co.OHG"
     reverse: "dnsp08.hansenet.de"
     country: "DE"
-  - 
+  -
     ip: "62.109.123.7"
     country: "DE"
     reverse: "dnsp10.hansenet.de"
     provider: "HANSENET Telefonica Germany GmbH & Co.OHG"
-  - 
+  -
     ip: "62.109.123.196"
     provider: "HANSENET Telefonica Germany GmbH & Co.OHG"
     reverse: "dnsp07.hansenet.de"
     country: "DE"
-  - 
+  -
     ip: "213.191.74.12"
     country: "DE"
     reverse: "dnsp03.hansenet.de"
     provider: "HANSENET Telefonica Germany GmbH & Co.OHG"
-  - 
+  -
     ip: "213.191.74.18"
     provider: "HANSENET Telefonica Germany GmbH & Co.OHG"
     reverse: "dnsp01.hansenet.de"
     country: "DE"
-  - 
+  -
     ip: "213.191.74.19"
     country: "DE"
     reverse: "dnsp03.hansenet.de"
     provider: "HANSENET Telefonica Germany GmbH & Co.OHG"
-  - 
+  -
     ip: "213.191.92.82"
     provider: "HANSENET Telefonica Germany GmbH & Co.OHG"
     reverse: "dnsp04.hansenet.de"
     country: "DE"
-  - 
+  -
     ip: "213.191.92.84"
     country: "DE"
     reverse: "dnsp02.hansenet.de"
     provider: "HANSENET Telefonica Germany GmbH & Co.OHG"
-  - 
+  -
     ip: "213.191.92.86"
     provider: "HANSENET Telefonica Germany GmbH & Co.OHG"
     reverse: "dnsp04.hansenet.de"
     country: "DE"
-  - 
+  -
     ip: "213.191.92.87"
     country: "DE"
     reverse: "dnsp02.hansenet.de"
     provider: "HANSENET Telefonica Germany GmbH & Co.OHG"
-  - 
+  -
     ip: "64.203.254.30"
     provider: "HARCOM1 - Hargray Communications Group, Inc."
     reverse: "ns1.hargray.com"
     country: "US"
-  - 
+  -
     ip: "195.178.123.130"
     country: "PL"
     reverse: "rysio.hds.pl"
     provider: "HDS-POLSKA-ASN HDS Polska Sp. z o.o."
-  - 
+  -
     ip: "213.157.0.193"
     country: "DE"
     reverse: "nsc.heagmedianet.de"
     provider: "HEAGMEDIANET HSE Medianet GmbH"
-  - 
+  -
     ip: "193.1.123.70"
     country: "IE"
     reverse: "ns.it-tallaght.ie"
     provider: "HEANET HEAnet Limited"
-  - 
+  -
     ip: "81.16.49.10"
     provider: "HERBST-AS Herbst Datentechnik GmbH"
     reverse: "ns1.serverpool.net"
     country: "DE"
-  - 
+  -
     ip: "91.198.179.11"
     country: "PL"
     reverse: "mail.hestia.pl"
     provider: "HESTIA Sopockie Towarzystwo Ubezpieczen Ergo Hestia S.A."
-  - 
+  -
     ip: "78.46.238.90"
     country: "DE"
     reverse: "timeserver.domainserver.de"
     provider: "HETZNER-AS Hetzner Online AG"
-  - 
+  -
     ip: "213.239.204.35"
     country: "DE"
     reverse: "mail.lkrauss.de"
     provider: "HETZNER-AS Hetzner Online AG"
-  - 
+  -
     ip: "118.88.20.195"
     provider: "HGAIT-AS-AU-AP DC West Pty. Ltd."
     reverse: "veyron.envisagenetworks.com.au"
     country: "AU"
-  - 
+  -
     ip: "216.185.64.6"
     provider: "HHES - HAMILTON HYDRO ELECTRIC SYSTEM"
     reverse: "ns1.fibrewired.on.ca"
     country: "CA"
-  - 
+  -
     ip: "216.185.64.10"
     country: "CA"
     reverse: "ns2.fibrewired.on.ca"
     provider: "HHES - HAMILTON HYDRO ELECTRIC SYSTEM"
-  - 
+  -
     ip: "69.16.169.11"
     country: "US"
     reverse: "dnscache01.easynews.com"
     provider: "HIGHWINDS - Highwinds Network Group, Inc."
-  - 
+  -
     ip: "69.16.170.11"
     provider: "HIGHWINDS - Highwinds Network Group, Inc."
     reverse: "dnscache02.easynews.com"
     country: "US"
-  - 
+  -
     ip: "193.17.192.53"
     country: "FR"
     reverse: "geeknode.hivane.net"
     provider: "HIVANE Hivane"
-  - 
+  -
     ip: "212.122.47.6"
     provider: "HLKOMM HL komm Telekommunikations GmbH"
     reverse: "bns.mux.nu"
     country: "DE"
-  - 
+  -
     ip: "62.129.252.252"
     country: "PL"
     reverse: "dns4.home.pl"
     provider: "HOMEPL-AS home.pl sp. z o.o."
-  - 
+  -
     ip: "212.85.112.32"
     provider: "HOMEPL-AS home.pl sp. z o.o."
     reverse: "dns4.home.pl"
     country: "PL"
-  - 
+  -
     ip: "64.20.26.17"
     provider: "HOMESC - Home Telephone Company, Inc."
     reverse: "dns1.homesc.com"
     country: "US"
-  - 
+  -
     ip: "64.20.26.145"
     country: "US"
     reverse: "dns2.homesc.com"
     provider: "HOMESC - Home Telephone Company, Inc."
-  - 
+  -
     ip: "46.163.76.32"
     country: "DE"
     reverse: "mx1.ipng.info"
     provider: "HOSTEUROPE-AS Host Europe GmbH"
-  - 
+  -
     ip: "80.237.197.14"
     country: "DE"
     reverse: "dns03.che.dt-internet.de"
     provider: "HOSTEUROPE-AS Host Europe GmbH"
-  - 
+  -
     ip: "217.72.162.2"
     provider: "HOTCHILLI Maxima Managed Services (Formerly: Hotchilli/DXI)"
     reverse: "dns0.hotchilli.net"
     country: "GB"
-  - 
+  -
     ip: "217.72.163.3"
     country: "GB"
     reverse: "dns1.hotchilli.net"
     provider: "HOTCHILLI Maxima Managed Services (Formerly: Hotchilli/DXI)"
-  - 
+  -
     ip: "217.72.171.53"
     provider: "HOTCHILLI Maxima Managed Services (Formerly: Hotchilli/DXI)"
     reverse: "dns.netcom.co.uk"
     country: "GB"
-  - 
+  -
     ip: "189.1.1.249"
     country: "BR"
     reverse: "ns2.hotlink.com.br"
     provider: "HOTLINK INTERNET LTDA"
-  - 
+  -
     ip: "15.227.128.50"
     provider: "HP-DIGITAL-10782 - Hewlett-Packard Company"
     reverse: "am1.hp.com"
     country: "US"
-  - 
+  -
     ip: "217.168.192.126"
     country: "PL"
     reverse: "ns1.hppoland.pl"
     provider: "HPPOLAND-AS Hewlett Packard Polska"
-  - 
+  -
     ip: "149.211.153.50"
     provider: "HP_WEBSERVICES Hewlett Packard GmbH"
     reverse: "nserver2.khis.de"
     country: "DE"
-  - 
+  -
     ip: "149.211.153.51"
     country: "DE"
     reverse: "nserver5.khis.de"
     provider: "HP_WEBSERVICES Hewlett Packard GmbH"
-  - 
+  -
     ip: "149.250.222.21"
     provider: "HP_WEBSERVICES Hewlett Packard GmbH"
     reverse: "nserver6.khis.de"
     country: "DE"
-  - 
+  -
     ip: "170.56.58.45"
     country: "DE"
     reverse: "nserver4.khis.de"
     provider: "HP_WEBSERVICES Hewlett Packard GmbH"
-  - 
+  -
     ip: "170.56.58.53"
     provider: "HP_WEBSERVICES Hewlett Packard GmbH"
     reverse: "nserver1.khis.de"
     country: "DE"
-  - 
+  -
     ip: "195.64.134.73"
     country: "CH"
     reverse: "ns3.hugy.ch"
     provider: "HUGY HuGy GmbH"
-  - 
+  -
     ip: "64.13.0.5"
     provider: "HUNTER-COMM - Hunter Communications"
     reverse: "64-13-0-5.mfd.clearwire-dns.net"
     country: "US"
-  - 
+  -
     ip: "74.82.42.42"
     country: "US"
     reverse: "ordns.he.net"
     provider: "HURRICANE - Hurricane Electric, Inc."
-  - 
+  -
     ip: "64.62.142.131"
     country: "US"
     reverse: "64.62.142.131"
     provider: "HURRICANE - Hurricane Electric, Inc."
-  - 
+  -
     ip: "74.82.46.6"
     provider: "HURRICANE - Hurricane Electric, Inc."
     reverse: "tserv1.tyo1.he.net"
     country: "US"
-  - 
+  -
     ip: "209.51.161.14"
     country: "US"
     reverse: "tserv1.nyc4.he.net"
     provider: "HURRICANE - Hurricane Electric, Inc."
-  - 
+  -
     ip: "216.66.22.2"
     provider: "HURRICANE - Hurricane Electric, Inc."
     reverse: "tserv2.ash1.he.net"
     country: "US"
-  - 
+  -
     ip: "216.66.80.30"
     country: "US"
     reverse: "tserv1.fra1.he.net"
     provider: "HURRICANE - Hurricane Electric, Inc."
-  - 
+  -
     ip: "216.66.80.90"
     provider: "HURRICANE - Hurricane Electric, Inc."
     reverse: "tserv1.sto1.he.net"
     country: "US"
-  - 
+  -
     ip: "216.66.80.98"
     country: "US"
     reverse: "tserv1.zrh1.he.net"
     provider: "HURRICANE - Hurricane Electric, Inc."
-  - 
+  -
     ip: "216.218.221.6"
     provider: "HURRICANE - Hurricane Electric, Inc."
     reverse: "tserv2.hkg1.he.net"
     country: "US"
-  - 
+  -
     ip: "216.218.226.238"
     country: "US"
     reverse: "tserv1.sea1.he.net"
     provider: "HURRICANE - Hurricane Electric, Inc."
-  - 
+  -
     ip: "142.46.128.130"
     provider: "HYDROONETELECOM - Hydro One Telecom Inc."
     reverse: "ns2.hydroonetelecom.com"
     country: "CA"
-  - 
+  -
     ip: "193.239.60.19"
     provider: "HYPERION-KT-AS HYPERION SA"
     reverse: "193.239.60.19"
     country: "PL"
-  - 
+  -
     ip: "81.90.208.3"
     country: "RU"
     reverse: "ns.hypernet.ru"
     provider: "HYPERNET-AS Limited Liability Company HyperNet"
-  - 
+  -
     ip: "194.30.220.119"
     country: "GR"
     reverse: "ns1.hol.gr"
     provider: "Hellas OnLine Electronic Communications S.A."
-  - 
+  -
     ip: "217.23.49.227"
     country: "DE"
     reverse: "ns3.i-netpartner.net"
     provider: "I-NETPARTNER-AS I-NetPartner GmbH"
-  - 
+  -
     ip: "217.23.50.18"
     provider: "I-NETPARTNER-AS I-NetPartner GmbH"
     reverse: "ns2.i-netpartner.net"
     country: "DE"
-  - 
+  -
     ip: "80.253.65.11"
     country: "ES"
     reverse: "ns1.iasoft.es"
     provider: "IASOFT-AS IA Soft Aragon AS Number"
-  - 
+  -
     ip: "129.186.142.200"
     country: "US"
     reverse: "ns-3.iastate.edu"
     provider: "IASTATE-AS - Iowa State University"
-  - 
+  -
     ip: "157.157.90.253"
     provider: "ICENET-AS1 Siminn hf"
     reverse: "dns.magnavik.is"
     country: "IS"
-  - 
+  -
     ip: "157.157.223.253"
     country: "IS"
     reverse: "ns1.hatidni.is"
     provider: "ICENET-AS1 Siminn hf"
-  - 
+  -
     ip: "213.167.155.16"
     provider: "ICENET-AS1 Siminn hf"
     reverse: "ns1.anza.is"
     country: "IS"
-  - 
+  -
     ip: "195.200.158.50"
     provider: "ICM-NETSERV-UK-AS ICM NetServ Ltd"
     reverse: "ns1.netserv.net"
     country: "GB"
-  - 
+  -
     ip: "212.87.21.2"
     country: "PL"
     reverse: "dna.iimcb.gov.pl"
     provider: "ICM-PUB University of Warsaw, ICM"
-  - 
+  -
     ip: "212.87.29.6"
     provider: "ICM-PUB University of Warsaw, ICM"
     reverse: "old.ibb.waw.pl"
     country: "PL"
-  - 
+  -
     ip: "209.133.21.10"
     country: "US"
     reverse: "ns1.got.net"
     provider: "ICO-SV - ICOnetworks"
-  - 
+  -
     ip: "210.48.65.1"
     country: "NZ"
     reverse: "ns1.iconz.co.nz"
     provider: "ICONZ-AS ICONZ Ltd"
-  - 
+  -
     ip: "212.101.201.139"
     country: "DE"
     reverse: "ihk.icsmedia.de"
     provider: "ICSMEDIA-DE ICSmedia GmbH"
-  - 
+  -
     ip: "83.143.154.234"
     provider: "IDC IDC Ltd."
     reverse: "mail.e37.ru"
     country: "RU"
-  - 
+  -
     ip: "217.15.32.2"
     country: "ES"
     reverse: "ns1.idatahouse.com"
     provider: "IDH Telvent Global Services S.A."
-  - 
+  -
     ip: "217.149.155.180"
     provider: "IDH Telvent Global Services S.A."
     reverse: "217-149-155-180.incotel.es"
     country: "ES"
-  - 
+  -
     ip: "193.29.202.193"
     country: "ES"
     reverse: "ns0.ie.edu"
     provider: "IEMPRESA-ES-AS Instituto de Empresa, S.L."
-  - 
+  -
     ip: "193.29.202.195"
     provider: "IEMPRESA-ES-AS Instituto de Empresa, S.L."
     reverse: "ns1.ie.edu"
     country: "ES"
-  - 
+  -
     ip: "82.198.129.138"
     provider: "IFN-AS INTERFUSION INET AS"
     reverse: "ns1.nethop.ie"
     country: "IE"
-  - 
+  -
     ip: "82.198.129.146"
     country: "IE"
     reverse: "ns2.nethop.ie"
     provider: "IFN-AS INTERFUSION INET AS"
-  - 
+  -
     ip: "208.66.232.66"
     country: "US"
     reverse: "ns65.web229.net"
     provider: "IIC-INTERNET - IIC Internet LLC"
-  - 
+  -
     ip: "202.232.2.38"
     provider: "IIJ Internet Initiative Japan Inc."
     reverse: "ns4.iij.ad.jp"
     country: "JP"
-  - 
+  -
     ip: "210.130.0.1"
     provider: "IIJ Internet Initiative Japan Inc."
     reverse: "ns01.iij4u.or.jp"
     country: "JP"
-  - 
+  -
     ip: "210.130.1.1"
     country: "JP"
     reverse: "ns11.iij4u.or.jp"
     provider: "IIJ Internet Initiative Japan Inc."
-  - 
+  -
     ip: "195.178.195.1"
     provider: "IIP-NET-AS5429 _UMOS CENTER_ LLC"
     reverse: "195.178.195.1"
     country: "RU"
-  - 
+  -
     ip: "195.178.208.158"
     country: "RU"
     reverse: "emergency.marika.ru"
     provider: "IIP-NET-AS5429 _UMOS CENTER_ LLC"
-  - 
+  -
     ip: "195.178.209.1"
     provider: "IIP-NET-AS5429 _UMOS CENTER_ LLC"
     reverse: "ns.umos.ru"
     country: "RU"
-  - 
+  -
     ip: "207.22.166.2"
     country: "US"
     reverse: "aslan.ij.net"
     provider: "IJ-NET - Internet Junction Corporation"
-  - 
+  -
     ip: "207.22.166.60"
     provider: "IJ-NET - Internet Junction Corporation"
     reverse: "dcs1.ij.net"
     country: "US"
-  - 
+  -
     ip: "207.22.166.61"
     country: "US"
     reverse: "ns2.ij.net"
     provider: "IJ-NET - Internet Junction Corporation"
-  - 
+  -
     ip: "80.67.48.254"
     country: "RU"
     reverse: "ns.achim.ru"
     provider: "IM-AS Limited Company _Intermedia_"
-  - 
+  -
     ip: "212.87.130.92"
     country: "DE"
     reverse: "ns1.imos.net"
     provider: "IMOS-AS imos GmbH"
-  - 
+  -
     ip: "212.87.132.53"
     provider: "IMOS-AS imos GmbH"
     reverse: "ns3.imos.net"
     country: "DE"
-  - 
+  -
     ip: "217.197.84.69"
     country: "DE"
     reverse: "ns5.free.de"
     provider: "IN-BERLIN-AS Individual Network Berlin e.V."
-  - 
+  -
     ip: "212.76.198.5"
     provider: "INCAS-AS INCAS GmbH"
     reverse: "ns.nordrhein.de"
     country: "DE"
-  - 
+  -
     ip: "193.200.133.86"
     provider: "INET-AS Beskid Media Sp.zoo"
     reverse: "hosting.beskidmedia.pl"
     country: "PL"
-  - 
+  -
     ip: "78.138.97.33"
     provider: "INETBONE-AS MESH GmbH"
     reverse: "ns3.ezdns.it"
     country: "DE"
-  - 
+  -
     ip: "78.138.98.82"
     country: "DE"
     reverse: "ns4.ezdns.it"
     provider: "INETBONE-AS MESH GmbH"
-  - 
+  -
     ip: "83.217.193.2"
     country: "RU"
     reverse: "ns2.infoline.su"
     provider: "INF-NET-AS LLC _Multiscan_"
-  - 
+  -
     ip: "193.202.117.38"
     country: "PL"
     reverse: "dnsb.infinite.pl"
     provider: "INFINITE-AS Infinite sp. z o.o."
-  - 
+  -
     ip: "195.248.226.1"
     country: "PL"
     reverse: "dnsa.infomex.pl"
     provider: "INFOMEX-AS Infomex Sp. z o.o."
-  - 
+  -
     ip: "195.225.76.3"
     provider: "INFOPLUS-AS INFOPLUS Joanna Operacz Leszek Chwalinski s.c."
     reverse: "ns.infoplus.com.pl"
     country: "PL"
-  - 
+  -
     ip: "217.169.242.2"
     provider: "INFOSAT-AS INFOSAT TELECOM S.A."
     reverse: "ns1.mcom.fr"
     country: "FR"
-  - 
+  -
     ip: "212.89.130.180"
     provider: "INFOSERVE-AS infoServe GmbH"
     reverse: "dns1.infoserve.de"
     country: "DE"
-  - 
+  -
     ip: "203.141.128.33"
     country: "JP"
     reverse: "tegtan1.interlink.or.jp"
     provider: "INFOSPHERE NTT PC Communications, Inc."
-  - 
+  -
     ip: "202.248.0.34"
     provider: "INFOWEB FUJITSU LIMITED"
     reverse: "ns.center.web.ad.jp"
     country: "JP"
-  - 
+  -
     ip: "202.248.2.201"
     country: "JP"
     reverse: "ns.web.ad.jp"
     provider: "INFOWEB FUJITSU LIMITED"
-  - 
+  -
     ip: "202.248.20.133"
     provider: "INFOWEB FUJITSU LIMITED"
     reverse: "dns5.nifty.com"
     country: "JP"
-  - 
+  -
     ip: "202.248.37.74"
     country: "JP"
     reverse: "dns.nifty.com"
     provider: "INFOWEB FUJITSU LIMITED"
-  - 
+  -
     ip: "210.131.113.123"
     provider: "INFOWEB FUJITSU LIMITED"
     reverse: "ns3.web.ad.jp"
     country: "JP"
-  - 
+  -
     ip: "212.94.0.66"
     country: "RU"
     reverse: "ns1.inges.ru"
     provider: "INGUSHELECTROSVYAZ-AS OJSC Ingushelectrosvyaz"
-  - 
+  -
     ip: "212.67.131.4"
     provider: "INOTEL-AS INOTEL S.A."
     reverse: "ns2.inotel.pl"
     country: "PL"
-  - 
+  -
     ip: "212.67.143.194"
     country: "PL"
     reverse: "ns1.inotel.pl"
     provider: "INOTEL-AS INOTEL S.A."
-  - 
+  -
     ip: "72.46.0.2"
     country: "US"
     reverse: "ns.intap.net"
     provider: "INTAP-1 - Intap, LLC"
-  - 
+  -
     ip: "64.140.128.10"
     provider: "INTEGRATELECOM - Integra Telecom, Inc."
     reverse: "ns.extremezone.com"
     country: "US"
-  - 
+  -
     ip: "64.140.128.11"
     country: "US"
     reverse: "ns2.extremezone.com"
     provider: "INTEGRATELECOM - Integra Telecom, Inc."
-  - 
+  -
     ip: "70.102.118.146"
     country: "US"
     reverse: "ns1.interstateconstructiongroup.com"
     provider: "INTEGRATELECOM - Integra Telecom, Inc."
-  - 
+  -
     ip: "87.236.240.66"
     provider: "INTERCOMGI Intercom Telematica Girona, S.L."
     reverse: "66.red-87-236-240.gro.conzentra.com"
     country: "ES"
-  - 
+  -
     ip: "87.236.240.67"
     country: "ES"
     reverse: "67.red-87-236-240.gro.conzentra.com"
     provider: "INTERCOMGI Intercom Telematica Girona, S.L."
-  - 
+  -
     ip: "87.236.240.70"
     provider: "INTERCOMGI Intercom Telematica Girona, S.L."
     reverse: "dns1.conzentra.com"
     country: "ES"
-  - 
+  -
     ip: "87.236.240.73"
     country: "ES"
     reverse: "dns4.conzentra.com"
     provider: "INTERCOMGI Intercom Telematica Girona, S.L."
-  - 
+  -
     ip: "87.236.240.83"
     provider: "INTERCOMGI Intercom Telematica Girona, S.L."
     reverse: "dns1.spamina.com"
     country: "ES"
-  - 
+  -
     ip: "188.94.8.72"
     provider: "INTERCOMGI-BCN Intercom Telematica Girona, S.L."
     reverse: "dns3.conzentra.com"
     country: "ES"
-  - 
+  -
     ip: "213.73.91.35"
     provider: "INTERDOTNET-LIG-AS Inter.Net Germany ligado operation"
     reverse: "dnscache.berlin.ccc.de"
     country: "DE"
-  - 
+  -
     ip: "66.151.145.1"
     provider: "INTERNAP-2BLK - Internap Network Services Corporation"
     reverse: "ns1.sje.pnap.net"
     country: "US"
-  - 
+  -
     ip: "69.25.1.33"
     provider: "INTERNAP-2BLK - Internap Network Services Corporation"
     reverse: "ns2.mia003.pnap.net"
     country: "US"
-  - 
+  -
     ip: "74.91.118.243"
     country: "US"
     reverse: "gatesj.alohadns.com"
     provider: "INTERNAP-2BLK - Internap Network Services Corporation"
-  - 
+  -
     ip: "216.52.65.1"
     country: "US"
     reverse: "ns1.phi.pnap.net"
     provider: "INTERNAP-2BLK - Internap Network Services Corporation"
-  - 
+  -
     ip: "216.52.65.33"
     provider: "INTERNAP-2BLK - Internap Network Services Corporation"
     reverse: "ns2.phi.pnap.net"
     country: "US"
-  - 
+  -
     ip: "216.52.97.33"
     country: "US"
     reverse: "ns2.ocy.pnap.net"
     provider: "INTERNAP-2BLK - Internap Network Services Corporation"
-  - 
+  -
     ip: "216.52.161.33"
     country: "US"
     reverse: "ns2.mia.pnap.net"
     provider: "INTERNAP-2BLK - Internap Network Services Corporation"
-  - 
+  -
     ip: "209.191.129.1"
     country: "US"
     reverse: "ns1.nyc.pnap.net"
     provider: "INTERNAP-BLK - Internap Network Services Corporation"
-  - 
+  -
     ip: "209.191.129.65"
     provider: "INTERNAP-BLK - Internap Network Services Corporation"
     reverse: "ns2.nyc.pnap.net"
     country: "US"
-  - 
+  -
     ip: "216.52.1.1"
     provider: "INTERNAP-BLK - Internap Network Services Corporation"
     reverse: "ns1.sfj.pnap.net"
     country: "US"
-  - 
+  -
     ip: "216.52.126.1"
     provider: "INTERNAP-BLK - Internap Network Services Corporation"
     reverse: "ns1.wdc002.pnap.net"
     country: "US"
-  - 
+  -
     ip: "216.52.254.1"
     country: "US"
     reverse: "ns1.lax.pnap.net"
     provider: "INTERNAP-BLK - Internap Network Services Corporation"
-  - 
+  -
     ip: "216.52.254.33"
     provider: "INTERNAP-BLK - Internap Network Services Corporation"
     reverse: "ns2.lax.pnap.net"
     country: "US"
-  - 
+  -
     ip: "216.52.41.1"
     country: "US"
     reverse: "ns1.den.pnap.net"
     provider: "INTERNAP-BLK3 - Internap Network Services Corporation"
-  - 
+  -
     ip: "216.52.41.33"
     provider: "INTERNAP-BLK3 - Internap Network Services Corporation"
     reverse: "ns2.den.pnap.net"
     country: "US"
-  - 
+  -
     ip: "216.52.94.1"
     country: "US"
     reverse: "ns1.nym.pnap.net"
     provider: "INTERNAP-BLK3 - Internap Network Services Corporation"
-  - 
+  -
     ip: "216.52.94.33"
     provider: "INTERNAP-BLK3 - Internap Network Services Corporation"
     reverse: "ns2.nym.pnap.net"
     country: "US"
-  - 
+  -
     ip: "216.52.169.1"
     provider: "INTERNAP-BLK3 - Internap Network Services Corporation"
     reverse: "ns1.hou.pnap.net"
     country: "US"
-  - 
+  -
     ip: "64.94.33.1"
     provider: "INTERNAP-BLK5 - Internap Network Services Corporation"
     reverse: "ns1.chg.pnap.net"
     country: "US"
-  - 
+  -
     ip: "63.251.62.1"
     country: "US"
     reverse: "ns1.sfo.pnap.net"
     provider: "INTERNAP-BLOCK-4 - Internap Network Services Corporation"
-  - 
+  -
     ip: "63.251.62.33"
     provider: "INTERNAP-BLOCK-4 - Internap Network Services Corporation"
     reverse: "ns2.sfo.pnap.net"
     country: "US"
-  - 
+  -
     ip: "63.251.129.1"
     country: "US"
     reverse: "ns1.bsn.pnap.net"
     provider: "INTERNAP-BLOCK-4 - Internap Network Services Corporation"
-  - 
+  -
     ip: "63.251.129.33"
     provider: "INTERNAP-BLOCK-4 - Internap Network Services Corporation"
     reverse: "ns2.bsn.pnap.net"
     country: "US"
-  - 
+  -
     ip: "63.251.161.1"
     country: "US"
     reverse: "ns1.sef.pnap.net"
     provider: "INTERNAP-BLOCK-4 - Internap Network Services Corporation"
-  - 
+  -
     ip: "63.251.161.33"
     provider: "INTERNAP-BLOCK-4 - Internap Network Services Corporation"
     reverse: "ns2.sef.pnap.net"
     country: "US"
-  - 
+  -
     ip: "64.94.1.1"
     provider: "INTERNAP-BLOCK-4 - Internap Network Services Corporation"
     reverse: "ns1.acs.pnap.net"
     country: "US"
-  - 
+  -
     ip: "64.94.1.33"
     country: "US"
     reverse: "ns2.acs.pnap.net"
     provider: "INTERNAP-BLOCK-4 - Internap Network Services Corporation"
-  - 
+  -
     ip: "206.253.194.65"
     provider: "INTERNAP-BLOCK-4 - Internap Network Services Corporation"
     reverse: "ns1.pnap.net"
     country: "US"
-  - 
+  -
     ip: "194.165.30.30"
     provider: "INTERNET-AS Internet Ltd."
     reverse: "ns.i9.ru"
     country: "RU"
-  - 
+  -
     ip: "85.158.1.37"
     provider: "INTERNET4YOU internet4YOU GmbH & Co. KG"
     reverse: "nserv1.ber.internet4you.de"
     country: "DE"
-  - 
+  -
     ip: "85.158.2.94"
     country: "DE"
     reverse: "nserv2.ber.internet4you.de"
     provider: "INTERNET4YOU internet4YOU GmbH & Co. KG"
-  - 
+  -
     ip: "193.41.116.20"
     provider: "INTERNET4YOU internet4YOU GmbH & Co. KG"
     reverse: "nserv1.internet4you.de"
     country: "DE"
-  - 
+  -
     ip: "193.41.117.20"
     country: "DE"
     reverse: "nserv2.internet4you.de"
     provider: "INTERNET4YOU internet4YOU GmbH & Co. KG"
-  - 
+  -
     ip: "62.233.128.17"
     provider: "INTERNETIA-AS Netia SA"
     reverse: "szafir.futuro.pl"
     country: "PL"
-  - 
+  -
     ip: "62.233.181.26"
     country: "PL"
     reverse: "lag-2.lodz.msk.pl"
     provider: "INTERNETIA-AS Netia SA"
-  - 
+  -
     ip: "81.210.49.10"
     country: "PL"
     reverse: "inter.zepter.com.pl"
     provider: "INTERNETIA-AS Netia SA"
-  - 
+  -
     ip: "83.238.39.254"
     provider: "INTERNETIA-AS Netia SA"
     reverse: "prometeusz.pub.sarocom.net"
     country: "PL"
-  - 
+  -
     ip: "83.238.255.76"
     country: "PL"
     reverse: "83-238-255-76.ip.netia.com.pl"
     provider: "INTERNETIA-AS Netia SA"
-  - 
+  -
     ip: "87.204.28.12"
     country: "PL"
     reverse: "dns2.futuro.pl"
     provider: "INTERNETIA-AS Netia SA"
-  - 
+  -
     ip: "195.114.173.153"
     country: "PL"
     reverse: "ns1.internetia.pl"
     provider: "INTERNETIA-AS Netia SA"
-  - 
+  -
     ip: "213.241.79.37"
     country: "PL"
     reverse: "dns1.inetia.pl"
     provider: "INTERNETIA-AS Netia SA"
-  - 
+  -
     ip: "62.69.212.14"
     country: "PL"
     reverse: "dns.ipartner.com.pl"
     provider: "INTERNETIA_ETTH2-AS Internetia Sp.z o.o."
-  - 
+  -
     ip: "89.187.240.59"
     country: "PL"
     reverse: "89-187-240-59.internetia.net.pl"
     provider: "INTERNETIA_ETTH2-AS Internetia Sp.z o.o."
-  - 
+  -
     ip: "89.187.240.60"
     provider: "INTERNETIA_ETTH2-AS Internetia Sp.z o.o."
     reverse: "89-187-240-60.internetia.net.pl"
     country: "PL"
-  - 
+  -
     ip: "194.150.238.2"
     provider: "INTERNETIA_ETTH2-AS Internetia Sp.z o.o."
     reverse: "mars.nj.pl"
     country: "PL"
-  - 
+  -
     ip: "62.116.144.150"
     country: "DE"
     reverse: "no1.unternehmen.com"
     provider: "INTERNETX-AS InterNetX GmbH"
-  - 
+  -
     ip: "89.146.204.5"
     provider: "INTERNET_AG INTERNET AG Global Network"
     reverse: "89.146.204.5"
     country: "DE"
-  - 
+  -
     ip: "194.187.242.8"
     country: "DE"
     reverse: "pns.gnl.net"
     provider: "INTERNET_AG INTERNET AG Global Network"
-  - 
+  -
     ip: "154.15.199.142"
     provider: "INTEROUTE Interoute Communications Limited"
     reverse: "res2.dns.interoute.net"
     country: "GB"
-  - 
+  -
     ip: "154.15.245.2"
     country: "GB"
     reverse: "res6.dns.uk.psi.net"
     provider: "INTEROUTE Interoute Communications Limited"
-  - 
+  -
     ip: "212.23.33.66"
     provider: "INTEROUTE Interoute Communications Limited"
     reverse: "ns1.interoute.net.uk"
     country: "GB"
-  - 
+  -
     ip: "94.190.64.2"
     provider: "INTERRA-AS INTERRA telecommunications group, Ltd."
     reverse: "ns.pervouralsk.ru"
     country: "RU"
-  - 
+  -
     ip: "94.190.68.2"
     country: "RU"
     reverse: "ns.kch.ru"
     provider: "INTERRA-AS INTERRA telecommunications group, Ltd."
-  - 
+  -
     ip: "80.251.144.5"
     provider: "INTERSAT-AS intersat Ltd"
     reverse: "ns1.intersat.ru"
     country: "RU"
-  - 
+  -
     ip: "194.6.240.1"
     provider: "INTRINSEC-AS INTRINSEC, France"
     reverse: "ns1.intrinsec.com"
     country: "FR"
-  - 
+  -
     ip: "194.6.240.2"
     country: "FR"
     reverse: "ns2.intrinsec.com"
     provider: "INTRINSEC-AS INTRINSEC, France"
-  - 
+  -
     ip: "62.177.45.82"
     provider: "INTURAL-AS CJSC _InT_"
     reverse: "ns.belnpp.ru"
     country: "RU"
-  - 
+  -
     ip: "212.75.171.80"
     country: "ES"
     reverse: "ns3.inycom.net"
     provider: "INYCOM INYCOM Autonomous System"
-  - 
+  -
     ip: "194.85.224.33"
     country: "RU"
     reverse: "relay.ioffe.ru"
     provider: "IOFFE-PHYSICAL-THECHICAL-INSTITUTE-AS Ioffe Physical-Technical Institute of the Russian Academy of Sciences"
-  - 
+  -
     ip: "212.84.161.163"
     country: "GB"
     reverse: "panther.dnsmaster.net"
     provider: "IOMART-AS Iomart"
-  - 
+  -
     ip: "212.84.181.99"
     provider: "IOMART-AS Iomart"
     reverse: "ns2.spellbox.net"
     country: "GB"
-  - 
+  -
     ip: "217.77.176.10"
     provider: "IOMART-AS Iomart"
     reverse: "ns1.titaninternet.co.uk"
     country: "GB"
-  - 
+  -
     ip: "217.77.176.11"
     country: "GB"
     reverse: "ns2.titaninternet.co.uk"
     provider: "IOMART-AS Iomart"
-  - 
+  -
     ip: "173.44.32.2"
     country: "US"
     reverse: "173.44.32.2"
     provider: "IPTELLIGENT - IPTelligent LLC"
-  - 
+  -
     ip: "189.38.95.96"
     provider: "IPV6 Internet Ltda"
     reverse: "dns2.gigadns.com.br"
     country: "BR"
-  - 
+  -
     ip: "80.190.248.146"
     country: "DE"
     reverse: "ns.de.tuxbox.nu"
     provider: "IPX-SERVER IPX Server GmbH"
-  - 
+  -
     ip: "195.20.112.252"
     country: "DE"
     reverse: "thegates.kommunity.net"
     provider: "IQOM-BUSINESS-AS iQom Business Services GmbH"
-  - 
+  -
     ip: "195.20.112.253"
     provider: "IQOM-BUSINESS-AS iQom Business Services GmbH"
     reverse: "gnom.kommunity.net"
     country: "DE"
-  - 
+  -
     ip: "78.110.144.2"
     provider: "IRTELCOM-AS Limited Liability Company Irtelcom"
     reverse: "ns.alania.net"
     country: "RU"
-  - 
+  -
     ip: "204.152.184.76"
     country: "US"
     reverse: "f.6to4servers.net"
     provider: "ISC-AS1280 Internet Systems Consortium, Inc."
-  - 
+  -
     ip: "202.83.95.227"
     provider: "ISEEK-AS-AP ISEEK Ltd"
     reverse: "ns8.jdcomputers.com.au"
     country: "AU"
-  - 
+  -
     ip: "77.41.229.2"
     country: "RU"
     reverse: "www.pkmtel.ru"
     provider: "ISI-AS OJSC _Vimpelcom_"
-  - 
+  -
     ip: "82.199.102.38"
     provider: "ISKRATELECOM-AS ISKRATELECOM ZAO"
     reverse: "ohelp.ru"
     country: "RU"
-  - 
+  -
     ip: "67.224.64.31"
     provider: "ISOLVER - Internet Solver, Inc."
     reverse: "ns1.internetsolver.com"
     country: "US"
-  - 
+  -
     ip: "66.9.182.1"
     provider: "ISPACE - Wave2Wave Communications, Inc"
     reverse: "resolv1.il.central.us.intellispace.net"
     country: "US"
-  - 
+  -
     ip: "85.31.186.15"
     provider: "ISPPRO-AS ISPpro Internet KG"
     reverse: "smartdns.base-t.com"
     country: "DE"
-  - 
+  -
     ip: "207.178.128.20"
     country: "US"
     reverse: "ns1.iswest.net"
     provider: "ISW - Internet Specialties West Inc."
-  - 
+  -
     ip: "207.178.128.21"
     provider: "ISW - Internet Specialties West Inc."
     reverse: "ns2.iswest.net"
     country: "US"
-  - 
+  -
     ip: "77.240.144.164"
     country: "RU"
     reverse: "ns.chuvashia.ru"
     provider: "ITECH-AS OJSC _VimpelCom_"
-  - 
+  -
     ip: "193.110.137.162"
     country: "PL"
     reverse: "dukla.itl.waw.pl"
     provider: "ITL-AS Instytut Lacznosci - Panstwowy Instytut Badawczy"
-  - 
+  -
     ip: "213.179.64.3"
     provider: "ITNS It-NetService GmbH"
     reverse: "ns1.itns.de"
     country: "DE"
-  - 
+  -
     ip: "213.179.65.3"
     country: "DE"
     reverse: "ns2.itns.de"
     provider: "ITNS It-NetService GmbH"
-  - 
+  -
     ip: "217.67.192.22"
     country: "PL"
     reverse: "ns2.itsa.pl"
     provider: "ITSA ITSA Autonomous System"
-  - 
+  -
     ip: "195.28.164.192"
     provider: "ITSS-AS Riffle Media BVBA"
     reverse: "rowlf.backup.bru.it-ss.be"
     country: "BE"
-  - 
+  -
     ip: "195.28.164.193"
     country: "BE"
     reverse: "fozzie.sql.bru.it-ss.be"
     provider: "ITSS-AS Riffle Media BVBA"
-  - 
+  -
     ip: "195.28.164.224"
     provider: "ITSS-AS Riffle Media BVBA"
     reverse: "piggy.riffle.be"
     country: "BE"
-  - 
+  -
     ip: "194.11.253.85"
     country: "GB"
     reverse: "nsefra01.capgemini.com"
     provider: "IXEUROPE-DE-FRANKFURT-ASN Equinix Germany (Previously IX Europe Germany AS)"
-  - 
+  -
     ip: "84.237.27.1"
     provider: "Institution of Russian Science Academy of Irkutsk Scientific Centre of Siberian Department of RAN"
     reverse: "irgups.ru"
     country: "RU"
-  - 
+  -
     ip: "212.118.241.1"
     provider: "Internap European Autonomous System"
     reverse: "ns1.lon.pnap.net"
     country: "GB"
-  - 
+  -
     ip: "212.118.241.33"
     country: "GB"
     reverse: "ns2.lon.pnap.net"
     provider: "Internap European Autonomous System"
-  - 
+  -
     ip: "195.35.111.4"
     country: "BE"
     reverse: "ns2.be.ihost.com"
     provider: "International Business Machines of Belgium Ltd"
-  - 
+  -
     ip: "194.117.245.2"
     country: "FR"
     reverse: "rosco.vayu.net"
     provider: "JAGUAR-AS Jaguar Network SAS"
-  - 
+  -
     ip: "128.86.249.14"
     country: "GB"
     reverse: "ns1.ulcc.ac.uk"
     provider: "JANET The JNT Association"
-  - 
+  -
     ip: "128.86.249.51"
     provider: "JANET The JNT Association"
     reverse: "hermes.ulcc.ac.uk"
     country: "GB"
-  - 
+  -
     ip: "78.31.159.225"
     country: "PL"
     reverse: "dns.jarsat.pl"
     provider: "JARSAT Jarsat s.c. Jaroslaw i Elzbieta Przedwojscy"
-  - 
+  -
     ip: "212.9.64.11"
     provider: "JAZZNET Jazz Telecom S.A."
     reverse: "ns1.datagrama.net"
     country: "ES"
-  - 
+  -
     ip: "212.9.64.12"
     country: "ES"
     reverse: "ns2.datagrama.net"
     provider: "JAZZNET Jazz Telecom S.A."
-  - 
+  -
     ip: "60.56.0.135"
     provider: "K-OPTICOM K-Opticom Corporation"
     reverse: "nscache3.eonet.ne.jp"
     country: "JP"
-  - 
+  -
     ip: "218.251.89.134"
     country: "JP"
     reverse: "nscache1.eonet.ne.jp"
     provider: "K-OPTICOM K-Opticom Corporation"
-  - 
+  -
     ip: "212.110.122.132"
     country: "DE"
     reverse: "dns01.reflact.com"
     provider: "KAMP-DE KAMP Netzwerkdienste GmbH"
-  - 
+  -
     ip: "62.213.205.134"
     provider: "KANGAROOT-AS Kangaroot BVBA"
     reverse: "ns2.combell.net"
     country: "BE"
-  - 
+  -
     ip: "83.69.77.2"
     country: "RU"
     reverse: "mail.inix.ru"
     provider: "KAVKAZ-TRANSTELECOM-AS CJSC _Caucasus - Transtelekom_"
-  - 
+  -
     ip: "202.14.102.1"
     provider: "KCCS-AS-AP KC Computer Service Ltd.,"
     reverse: "kcbbs.kci.net.nz"
     country: "NZ"
-  - 
+  -
     ip: "216.241.132.2"
     country: "US"
     reverse: "ns2.kconlineinc.com"
     provider: "KCOL - KC Online, Inc."
-  - 
+  -
     ip: "194.164.183.2"
     provider: "KCOM-SPN KCOM Group PLC"
     reverse: "ns2.pins.co.uk"
     country: "GB"
-  - 
+  -
     ip: "194.164.183.10"
     country: "GB"
     reverse: "ns.pins.co.uk"
     provider: "KCOM-SPN KCOM Group PLC"
-  - 
+  -
     ip: "106.186.17.181"
     provider: "KDDI KDDI CORPORATION"
     reverse: "tungsten.gparent.org"
     country: "JP"
-  - 
+  -
     ip: "210.141.112.163"
     country: "JP"
     reverse: "bind1.dion.ne.jp"
     provider: "KDDI KDDI CORPORATION"
-  - 
+  -
     ip: "210.196.3.183"
     country: "JP"
     reverse: "bind.dion.ne.jp"
     provider: "KDDI KDDI CORPORATION"
-  - 
+  -
     ip: "210.250.61.4"
     country: "JP"
     reverse: "dns4.ambisys.jp"
     provider: "KDDI KDDI CORPORATION"
-  - 
+  -
     ip: "202.17.97.10"
     country: "JP"
     reverse: "ns.lib.wakayama-c.ed.jp"
     provider: "KE-NET Wakayama Prefectural Government"
-  - 
+  -
     ip: "212.9.96.21"
     provider: "KEYCOM-AS Keycom PLC"
     reverse: "dns2.keycom.co.uk"
     country: "GB"
-  - 
+  -
     ip: "212.9.98.20"
     country: "GB"
     reverse: "dns1.keycom.co.uk"
     provider: "KEYCOM-AS Keycom PLC"
-  - 
+  -
     ip: "87.118.111.215"
     country: "DE"
     reverse: "ns.crawford.de.fooldns.com"
     provider: "KEYWEB-AS Keyweb AG"
-  - 
+  -
     ip: "90.189.109.2"
     country: "RU"
     reverse: "ns.khakasnet.ru"
     provider: "KHAKAS-AS OJSC Rostelecom"
-  - 
+  -
     ip: "82.199.32.34"
     provider: "KNET Comunicaciones S.L."
     reverse: "dns1.knet.es"
     country: "ES"
-  - 
+  -
     ip: "82.199.32.36"
     country: "ES"
     reverse: "dns2.knet.es"
     provider: "KNET Comunicaciones S.L."
-  - 
+  -
     ip: "195.253.2.54"
     provider: "KNIPP-AS Knipp Medien und Kommunikation GmbH"
     reverse: "hp9000.do.knipp.de"
     country: "DE"
-  - 
+  -
     ip: "195.244.25.3"
     provider: "KOLCHUG-INFO-AS Kolchug-INFO Ltd."
     reverse: "www.kolchug.info"
     country: "RU"
-  - 
+  -
     ip: "195.24.228.3"
     country: "RU"
     reverse: "ns1.m-invest.ru"
     provider: "KOMPANIYA-METALLINVEST-AS Kompaniya Metallinvest Ltd."
-  - 
+  -
     ip: "62.134.40.53"
     provider: "KOMRO-AS komro GmbH"
     reverse: "ns.komro.net"
     country: "DE"
-  - 
+  -
     ip: "62.108.161.200"
     country: "PL"
     reverse: "dns.koszalin.pl"
     provider: "KOSMAN-EDU-AS Technical University of Koszalin"
-  - 
+  -
     ip: "193.141.43.129"
     country: "EU"
     reverse: "frankfurt.nic.xlink.net"
     provider: "KPN KPN Internet Backbone"
-  - 
+  -
     ip: "194.45.12.2"
     country: "EU"
     reverse: "dns.antech.de"
     provider: "KPN KPN Internet Backbone"
-  - 
+  -
     ip: "80.80.111.254"
     provider: "KR-ROSTOV Mobile TeleSystems Open Joint Stock Company"
     reverse: "ns.aaanet.ru"
     country: "RU"
-  - 
+  -
     ip: "80.253.225.3"
     country: "RU"
     reverse: "ns.ktk.ru"
     provider: "KRASTELECOM-AS Company Krastelekom Ltd."
-  - 
+  -
     ip: "193.9.123.19"
     provider: "KRDC-AS KRDC Sp. z o.o"
     reverse: "poczta.ip24.pl"
     country: "PL"
-  - 
+  -
     ip: "193.9.123.51"
     country: "PL"
     reverse: "host-12.krdc.pl"
     provider: "KRDC-AS KRDC Sp. z o.o"
-  - 
+  -
     ip: "212.192.128.3"
     country: "RU"
     reverse: "mail.kubannet.ru"
     provider: "KUBANNET State educational institution of higher education Kuban State University"
-  - 
+  -
     ip: "194.110.253.2"
     country: "RU"
     reverse: "ns.kuntsevo.net"
     provider: "KUNTSEVONET-AS SITS Ltd"
-  - 
+  -
     ip: "194.110.253.230"
     provider: "KUNTSEVONET-AS SITS Ltd"
     reverse: "dt.zao.msk.ru"
     country: "RU"
-  - 
+  -
     ip: "80.245.240.76"
     country: "RU"
     reverse: "ns1.xdx.ru"
     provider: "KVANT-AS Kvant ltd."
-  - 
+  -
     ip: "81.209.202.46"
     provider: "LAMBDANET-AS euNetworks Managed Services GmbH"
     reverse: "ns-res3.eu.lambdanet.net"
     country: "DE"
-  - 
+  -
     ip: "217.71.105.254"
     country: "DE"
     reverse: "ns-res2.eu.lambdanet.net"
     provider: "LAMBDANET-AS euNetworks Managed Services GmbH"
-  - 
+  -
     ip: "217.79.225.8"
     country: "RU"
     reverse: "ns.lancronix.ru"
     provider: "LANCRONIX-AS LANCRONIX LTD"
-  - 
+  -
     ip: "80.77.25.2"
     provider: "LAXIN-AS Laxin IT-Services GmbH & Co. KG"
     reverse: "ns.gammax.net"
     country: "DE"
-  - 
+  -
     ip: "208.86.117.40"
     country: "US"
     reverse: "ns1.tandemcomm.net"
     provider: "LAYER-7-NETWORKS - Layer 7 Consulting, LLC"
-  - 
+  -
     ip: "80.118.192.100"
     country: "FR"
     reverse: "ns0.gaoland.net"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
-  - 
+  -
     ip: "80.118.192.111"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
     reverse: "111.192.118.80.rev.sfr.net"
     country: "FR"
-  - 
+  -
     ip: "80.118.196.41"
     country: "FR"
     reverse: "41.196.118.80.rev.sfr.net"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
-  - 
+  -
     ip: "84.103.237.140"
     country: "FR"
     reverse: "ns1.rslv.n9uf.net"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
-  - 
+  -
     ip: "84.103.237.141"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
     reverse: "ns3.rslv.n9uf.net"
     country: "FR"
-  - 
+  -
     ip: "84.103.237.142"
     country: "FR"
     reverse: "ns5.rslv.n9uf.net"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
-  - 
+  -
     ip: "84.103.237.143"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
     reverse: "ns7.rslv.n9uf.net"
     country: "FR"
-  - 
+  -
     ip: "84.103.237.144"
     country: "FR"
     reverse: "ns9.rslv.n9uf.net"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
-  - 
+  -
     ip: "84.103.237.145"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
     reverse: "ns11.rslv.n9uf.net"
     country: "FR"
-  - 
+  -
     ip: "84.103.237.146"
     country: "FR"
     reverse: "ns13.rslv.n9uf.net"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
-  - 
+  -
     ip: "84.103.237.147"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
     reverse: "ns15.rslv.n9uf.net"
     country: "FR"
-  - 
+  -
     ip: "84.103.237.148"
     country: "FR"
     reverse: "ns17.rslv.n9uf.net"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
-  - 
+  -
     ip: "86.64.145.140"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
     reverse: "ns0.rslv.n9uf.net"
     country: "FR"
-  - 
+  -
     ip: "86.64.145.141"
     country: "FR"
     reverse: "ns2.rslv.n9uf.net"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
-  - 
+  -
     ip: "86.64.145.142"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
     reverse: "ns4.rslv.n9uf.net"
     country: "FR"
-  - 
+  -
     ip: "86.64.145.143"
     country: "FR"
     reverse: "ns6.rslv.n9uf.net"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
-  - 
+  -
     ip: "86.64.145.145"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
     reverse: "ns10.rslv.n9uf.net"
     country: "FR"
-  - 
+  -
     ip: "86.64.145.146"
     country: "FR"
     reverse: "ns12.rslv.n9uf.net"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
-  - 
+  -
     ip: "86.64.145.147"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
     reverse: "147.145.64.86.rev.sfr.net"
     country: "FR"
-  - 
+  -
     ip: "86.64.145.148"
     country: "FR"
     reverse: "148.145.64.86.rev.sfr.net"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
-  - 
+  -
     ip: "109.0.64.242"
     country: "FR"
     reverse: "242.64.0.109.rev.sfr.net"
     provider: "LDCOMNET Societe Francaise du Radiotelephone S.A"
-  - 
+  -
     ip: "37.1.195.200"
     provider: "LEASEWEB LeaseWeb B.V."
     reverse: "37.1.195.200"
     country: "NL"
-  - 
+  -
     ip: "217.28.96.190"
     country: "DE"
     reverse: "ns2.leitwerk.net"
     provider: "LEITWERK-AS LEITWERK AG"
-  - 
+  -
     ip: "217.28.98.62"
     provider: "LEITWERK-AS LEITWERK AG"
     reverse: "ns.leitwerk.net"
     country: "DE"
-  - 
+  -
     ip: "212.203.33.12"
     provider: "LEU-AS Leunet AG"
     reverse: "212.203.33.12"
     country: "CH"
-  - 
+  -
     ip: "212.203.33.113"
     country: "CH"
     reverse: "212.203.33.113"
     provider: "LEU-AS Leunet AG"
-  - 
+  -
     ip: "4.2.2.1"
     country: "US"
     reverse: "a.resolvers.level3.net"
     provider: "LEVEL3 Level 3 Communications"
-  - 
+  -
     ip: "4.2.2.2"
     country: "US"
     reverse: "b.resolvers.level3.net"
     provider: "LEVEL3 Level 3 Communications"
-  - 
+  -
     ip: "4.2.2.3"
     country: "US"
     reverse: "c.resolvers.level3.net"
     provider: "LEVEL3 Level 3 Communications"
-  - 
+  -
     ip: "4.2.2.4"
     country: "US"
     reverse: "d.resolvers.level3.net"
     provider: "LEVEL3 Level 3 Communications"
-  - 
+  -
     ip: "4.2.2.5"
     country: "US"
     reverse: "e.resolvers.level3.net"
     provider: "LEVEL3 Level 3 Communications"
-  - 
+  -
     ip: "4.2.2.6"
     country: "US"
     reverse: "resolver8.level3.net"
     provider: "LEVEL3 Level 3 Communications"
-  - 
+  -
     ip: "4.79.132.219"
     provider: "LEVEL3 Level 3 Communications"
     reverse: "ns1.sotelips.net"
     country: "US"
-  - 
+  -
     ip: "8.3.48.20"
     country: "US"
     reverse: "dns1.linknetinc.com"
     provider: "LEVEL3 Level 3 Communications"
-  - 
+  -
     ip: "8.3.48.30"
     provider: "LEVEL3 Level 3 Communications"
     reverse: "dns2.linknetinc.com"
     country: "US"
-  - 
+  -
     ip: "65.57.163.9"
     country: "US"
     reverse: "ns1.co-location.com"
     provider: "LEVEL3 Level 3 Communications"
-  - 
+  -
     ip: "80.253.111.164"
     provider: "LEVEL3 Level 3 Communications"
     reverse: "ns1.trumanbrewery.net"
     country: "US"
-  - 
+  -
     ip: "209.0.205.11"
     country: "US"
     reverse: "ns1.bigcity.net"
     provider: "LEVEL3 Level 3 Communications"
-  - 
+  -
     ip: "209.0.205.50"
     provider: "LEVEL3 Level 3 Communications"
     reverse: "ns2.bigcity.net"
     country: "US"
-  - 
+  -
     ip: "209.244.0.3"
     country: "US"
     reverse: "resolver1.level3.net"
     provider: "LEVEL3 Level 3 Communications"
-  - 
+  -
     ip: "209.244.0.4"
     provider: "LEVEL3 Level 3 Communications"
     reverse: "resolver2.level3.net"
     country: "US"
-  - 
+  -
     ip: "212.3.252.131"
     country: "US"
     reverse: "ns1.rack66.net"
     provider: "LEVEL3 Level 3 Communications"
-  - 
+  -
     ip: "212.118.196.121"
     provider: "LEWTELNET LEWTelNet GmbH"
     reverse: "ns2.allinone.de"
     country: "DE"
-  - 
+  -
     ip: "212.118.210.253"
     country: "DE"
     reverse: "ns.allinone.de"
     provider: "LEWTELNET LEWTelNet GmbH"
-  - 
+  -
     ip: "212.9.160.1"
     provider: "LFNET-AS01 LF.net GmbH"
     reverse: "ns.lf.net"
     country: "DE"
-  - 
+  -
     ip: "212.9.161.2"
     country: "DE"
     reverse: "ns.ispeg.de"
     provider: "LFNET-AS01 LF.net GmbH"
-  - 
+  -
     ip: "212.118.160.1"
     provider: "LFNET-AS01 LF.net GmbH"
     reverse: "ns.oberon.net"
     country: "DE"
-  - 
+  -
     ip: "212.118.160.3"
     country: "DE"
     reverse: "ns2.oberon.net"
     provider: "LFNET-AS01 LF.net GmbH"
-  - 
+  -
     ip: "77.59.224.11"
     provider: "LGI-UPC Liberty Global Operations B.V."
     reverse: "ns2.newday.ch"
     country: "AT"
-  - 
+  -
     ip: "77.59.244.151"
     country: "AT"
     reverse: "ns2.vswiss.net"
     provider: "LGI-UPC Liberty Global Operations B.V."
-  - 
+  -
     ip: "193.41.90.30"
     country: "AT"
     reverse: "mail.frey-net.ch"
     provider: "LGI-UPC Liberty Global Operations B.V."
-  - 
+  -
     ip: "193.47.120.6"
     country: "AT"
     reverse: "xdns02.ag.ch"
     provider: "LGI-UPC Liberty Global Operations B.V."
-  - 
+  -
     ip: "217.168.40.198"
     provider: "LGI-UPC Liberty Global Operations B.V."
     reverse: "dns1.zentral-labor.ch"
     country: "AT"
-  - 
+  -
     ip: "195.88.84.100"
     provider: "LIAZO Liazo SARL"
     reverse: "noc.toile-libre.net"
     country: "FR"
-  - 
+  -
     ip: "216.81.128.132"
     country: "US"
     reverse: "nscache3-mngt.dsm.lightedge.com"
     provider: "LIGHTEDGE - LightEdge Solutions"
-  - 
+  -
     ip: "91.208.32.2"
     country: "PL"
     reverse: "earth.balta.pl"
     provider: "LIMES-AS LIMES s.c."
-  - 
+  -
     ip: "91.208.32.5"
     provider: "LIMES-AS LIMES s.c."
     reverse: "merkuryb.balta.pl"
     country: "PL"
-  - 
+  -
     ip: "208.115.243.35"
     country: "US"
     reverse: "35-243-115-208.static.reverse.lstn.net"
     provider: "LIMESTONENETWORKS - Limestone Networks, Inc."
-  - 
+  -
     ip: "89.208.96.254"
     provider: "LINEGROUP-AS Line-Group.Ru"
     reverse: "ns2.line-group.ru"
     country: "RU"
-  - 
+  -
     ip: "89.208.97.197"
     country: "RU"
     reverse: "ns1.line-group.ru"
     provider: "LINEGROUP-AS Line-Group.Ru"
-  - 
+  -
     ip: "194.169.211.252"
     provider: "LINK11 Link11 GmbH"
     reverse: "ns2.monsterserver.de"
     country: "DE"
-  - 
+  -
     ip: "194.149.72.2"
     country: "ES"
     reverse: "ns1.lnst.es"
     provider: "LLEIDANET LleidaNetworks Serveis Telematics S.A."
-  - 
+  -
     ip: "69.28.136.102"
     provider: "LLNW-AS Limelight Networks, INC. proxy AS object"
     reverse: "cachedns.phx1.llnw.net"
     country: "US"
-  - 
+  -
     ip: "69.28.148.102"
     country: "US"
     reverse: "cachedns.sjc.llnw.net"
     provider: "LLNW-AS Limelight Networks, INC. proxy AS object"
-  - 
+  -
     ip: "208.112.89.187"
     provider: "LNH-INC - HostMySite"
     reverse: "cache.dc2.hostmysite.net"
     country: "US"
-  - 
+  -
     ip: "206.130.130.2"
     country: "US"
     reverse: "ns1.nwinternet.com"
     provider: "LOCALTEL - LocalTel Communications"
-  - 
+  -
     ip: "206.130.133.2"
     provider: "LOCALTEL - LocalTel Communications"
     reverse: "ns2.nwinternet.com"
     country: "US"
-  - 
+  -
     ip: "195.245.76.6"
     country: "RU"
     reverse: "gw1.logika.ru"
     provider: "LOGIKA-AS OOO NPP LOGIKA"
-  - 
+  -
     ip: "91.194.58.20"
     country: "RU"
     reverse: "ns.logis.ru"
     provider: "LOGIS-AS CJSC Nauchno-technicheskiy centr lokalnih i geograficheskih sistem"
-  - 
+  -
     ip: "193.41.238.1"
     provider: "LONGPHONE LONGPHONE"
     reverse: "193-41-238-1.longphone.fr"
     country: "FR"
-  - 
+  -
     ip: "147.126.240.2"
     country: "US"
     reverse: "luhsdns2.luhs.org"
     provider: "LOYOLA-UNIV-CHICAGO - Loyola University Chicago"
-  - 
+  -
     ip: "194.1.144.29"
     country: "PL"
     reverse: "ns1.lp.pl"
     provider: "LPPL-AS LP.PL"
-  - 
+  -
     ip: "85.235.205.2"
     country: "RU"
     reverse: "ns2.lsi.spb.ru"
     provider: "LSINET LenStroyInform Ltd AS"
-  - 
+  -
     ip: "198.237.209.130"
     provider: "LSNET - LS Networks"
     reverse: "ns.coos.k12.or.us"
     country: "US"
-  - 
+  -
     ip: "131.166.12.3"
     country: "DK"
     reverse: "dupont.dannet.dk"
     provider: "MACH-APS MACH Aps"
-  - 
+  -
     ip: "194.242.50.66"
     country: "DK"
     reverse: "ns2.e2e-center.com"
     provider: "MACH-APS MACH Aps"
-  - 
+  -
     ip: "195.128.85.185"
     country: "RU"
     reverse: "ns1.lt.ru"
     provider: "MACOMNET CJSC Macomnet"
-  - 
+  -
     ip: "79.140.64.2"
     country: "RU"
     reverse: "ns.magistraly.ru"
     provider: "MAGISTRALY-RU OJSC _Vimpelcom_"
-  - 
+  -
     ip: "79.140.64.3"
     provider: "MAGISTRALY-RU OJSC _Vimpelcom_"
     reverse: "ns2.magistraly.ru"
     country: "RU"
-  - 
+  -
     ip: "216.118.209.5"
     country: "CA"
     reverse: "ns1.magna.com"
     provider: "MAGNANET - Magna International Inc."
-  - 
+  -
     ip: "202.28.162.1"
     country: "TH"
     reverse: "ns1.mahidol.ac.th"
     provider: "MAHIDOL-BORDER-AS Mahidol University, Thailand"
-  - 
+  -
     ip: "78.143.192.10"
     country: "GB"
     reverse: "dnscache1.fast.co.uk"
     provider: "MAILBOX Mailbox Networks"
-  - 
+  -
     ip: "193.239.136.62"
     country: "PL"
     reverse: "ns1.makolab.pl"
     provider: "MAKOLAB Makolab S.A."
-  - 
+  -
     ip: "188.114.194.2"
     country: "RU"
     reverse: "ns11.compot.ru"
     provider: "MAKSIM-AS MAKSIM Co. Ltd."
-  - 
+  -
     ip: "213.5.24.3"
     provider: "MALNET-AS Malnet LTD."
     reverse: "ns1.malnet.ru"
     country: "RU"
-  - 
+  -
     ip: "213.5.28.2"
     country: "RU"
     reverse: "ns2.malnet.ru"
     provider: "MALNET-AS Malnet LTD."
-  - 
+  -
     ip: "77.75.184.4"
     provider: "MANCHESTERMETRONET Metronet (UK) Limited"
     reverse: "ns1.metronet-uk.com"
     country: "GB"
-  - 
+  -
     ip: "193.194.148.20"
     country: "DE"
     reverse: "ns.welfen.net"
     provider: "MANDALA-AS Mandala Internet EDV Service GmbH"
-  - 
+  -
     ip: "193.194.149.101"
     provider: "MANDALA-AS Mandala Internet EDV Service GmbH"
     reverse: "193.194.149.101"
     country: "DE"
-  - 
+  -
     ip: "66.187.32.10"
     provider: "MAQSNET - MARQUETTE-ADAMS TELEPHONE COOPERATIVE, INC."
     reverse: "garnet.maqs.net"
     country: "US"
-  - 
+  -
     ip: "204.8.180.42"
     country: "US"
     reverse: "ns2.marliness.net"
     provider: "MARLIN - Marlin eSourcing Solutions"
-  - 
+  -
     ip: "94.72.64.11"
     provider: "MARSOFT-AS Marsoft S.A."
     reverse: "dns2.marsoft.net"
     country: "PL"
-  - 
+  -
     ip: "69.10.201.27"
     provider: "MASHELL-TELECOM - Rainier Connect"
     reverse: "ns1.localaccess.com"
     country: "US"
-  - 
+  -
     ip: "87.242.75.120"
     country: "RU"
     reverse: "87.242.75.120"
     provider: "MASTERHOST-AS .masterhost autonomous system"
-  - 
+  -
     ip: "85.249.40.8"
     provider: "MASTERIT Master IT Ltd."
     reverse: "8-40-249-85-static.master.ru"
     country: "RU"
-  - 
+  -
     ip: "85.249.45.253"
     country: "RU"
     reverse: "ns3.master.ru"
     provider: "MASTERIT Master IT Ltd."
-  - 
+  -
     ip: "195.112.96.34"
     provider: "MAXNET Autonomous System for"
     reverse: "ns.maxnet.ru"
     country: "RU"
-  - 
+  -
     ip: "202.89.58.97"
     country: "AU"
     reverse: "nsrec01.maxnet.net.nz"
     provider: "MAXNET-NZ-AP Auckland"
-  - 
+  -
     ip: "202.89.58.98"
     provider: "MAXNET-NZ-AP Auckland"
     reverse: "nsrec02.maxnet.net.nz"
     country: "AU"
-  - 
+  -
     ip: "193.111.34.18"
     provider: "MBK-NETWORKS-AS mbk networks GmbH"
     reverse: "auth01.mbk-networks.com"
     country: "DE"
-  - 
+  -
     ip: "193.201.153.1"
     country: "GB"
     reverse: "dmz1.mblox.com"
     provider: "MBLOX-AS Mblox Ltd"
-  - 
+  -
     ip: "194.169.234.136"
     country: "GB"
     reverse: "ns2.mbmltd.co.uk"
     provider: "MBMLTD Micro-Business Maintenance Ltd"
-  - 
+  -
     ip: "199.249.18.1"
     country: "US"
     reverse: "cache-ns2.verizonbusiness.com"
     provider: "MCI-ASN - MCI"
-  - 
+  -
     ip: "199.249.19.1"
     provider: "MCI-ASN - MCI"
     reverse: "cache-ns1.verizonbusiness.com"
     country: "US"
-  - 
+  -
     ip: "91.143.20.6"
     country: "RU"
     reverse: "ns.megalog.ru"
     provider: "MEGALOG-PLUS-AS Megalog-Plus Ltd"
-  - 
+  -
     ip: "94.100.81.2"
     country: "RU"
     reverse: "mail.mp-nn.ru"
     provider: "MEGANN-AS Mega-N Ltd."
-  - 
+  -
     ip: "64.218.170.254"
     provider: "MEGAPATH2-US - MegaPath Networks Inc."
     reverse: "ns1.megapath.net"
     country: "US"
-  - 
+  -
     ip: "35.8.2.41"
     provider: "MERIT-AS-14 - Merit Network Inc."
     reverse: "serv1.cl.msu.edu"
     country: "US"
-  - 
+  -
     ip: "35.8.2.42"
     country: "US"
     reverse: "serv2.cl.msu.edu"
     provider: "MERIT-AS-14 - Merit Network Inc."
-  - 
+  -
     ip: "35.8.2.45"
     provider: "MERIT-AS-14 - Merit Network Inc."
     reverse: "nmserv1.ats.msu.edu"
     country: "US"
-  - 
+  -
     ip: "35.8.98.43"
     country: "US"
     reverse: "serv3.cl.msu.edu"
     provider: "MERIT-AS-14 - Merit Network Inc."
-  - 
+  -
     ip: "193.102.59.190"
     country: "DE"
     reverse: "ns5.messefrankfurt.com"
     provider: "MESSEFFM Messe Frankfurt GmbH"
-  - 
+  -
     ip: "193.109.4.5"
     provider: "MESSEFFM Messe Frankfurt GmbH"
     reverse: "ns.messefrankfurt.com"
     country: "DE"
-  - 
+  -
     ip: "212.129.64.2"
     country: "IE"
     reverse: "ns2.meteor.ie"
     provider: "METEORMOBILECOMMS-AS Meteor Mobile Communication Ireland"
-  - 
+  -
     ip: "216.194.28.33"
     country: "US"
     reverse: "ns1.metconnect.net"
     provider: "METTEL - Metropolitan Telecomm"
-  - 
+  -
     ip: "216.194.28.69"
     provider: "METTEL - Metropolitan Telecomm"
     reverse: "ns2.metconnect.net"
     country: "US"
-  - 
+  -
     ip: "83.149.32.2"
     country: "RU"
     reverse: "ns.ugsm.ru"
     provider: "MF-UGSM-AS OJSC MegaFon"
-  - 
+  -
     ip: "24.224.127.197"
     country: "US"
     reverse: "dns1.mi-connection.com"
     provider: "MI-CONNECTION - MI-Connection Communications System"
-  - 
+  -
     ip: "194.8.70.10"
     country: "RU"
     reverse: "194.8.70.10"
     provider: "MIA-AS Ministry of Interior Affairs of Russian Federation"
-  - 
+  -
     ip: "195.225.36.2"
     provider: "MICONET-AS Miconet Sp. z o.o."
     reverse: "dns.miconet.pl"
     country: "PL"
-  - 
+  -
     ip: "195.225.36.16"
     country: "PL"
     reverse: "dns1.miconet.pl"
     provider: "MICONET-AS Miconet Sp. z o.o."
-  - 
+  -
     ip: "65.220.16.14"
     country: "US"
     reverse: "ns1.sysgrp.net"
     provider: "MICROCERV - MicroCerv"
-  - 
+  -
     ip: "24.220.0.10"
     provider: "MIDCO-NET - Midcontinent Media, Inc."
     reverse: "dns1.midco.net"
     country: "US"
-  - 
+  -
     ip: "72.2.217.249"
     country: "US"
     reverse: "ns2.myclearwave.net"
     provider: "MIDWESTWIRELESS - Cellco Partnership DBA Verizon Wireless"
-  - 
+  -
     ip: "203.112.2.4"
     country: "JP"
     reverse: "ns01.miinet.jp"
     provider: "MIINET UCOM Corporation"
-  - 
+  -
     ip: "203.112.2.5"
     provider: "MIINET UCOM Corporation"
     reverse: "ns02.miinet.jp"
     country: "JP"
-  - 
+  -
     ip: "194.50.10.2"
     country: "RU"
     reverse: "ck.mkm.ru"
     provider: "MKM-AS ZAO Moskabelmet"
-  - 
+  -
     ip: "193.16.208.114"
     country: "RU"
     reverse: "ns1.mmk.ru"
     provider: "MMK-AS OAO Magnitogorsk Iron and Steel works"
-  - 
+  -
     ip: "193.16.209.2"
     provider: "MMK-AS OAO Magnitogorsk Iron and Steel works"
     reverse: "ns2.mmk.ru"
     country: "RU"
-  - 
+  -
     ip: "212.114.209.107"
     country: "DE"
     reverse: "n4.n-online.net"
     provider: "MNET-AS M-net Telekommunikations GmbH, Germany"
-  - 
+  -
     ip: "193.138.233.10"
     provider: "MNW-AS MNW Co Ltd"
     reverse: "mail.colo.su"
     country: "RU"
-  - 
+  -
     ip: "80.254.79.157"
     provider: "MONZOON-AS Monzoon Networks AG"
     reverse: "zrh1-ns01.monzoon.net"
     country: "CH"
-  - 
+  -
     ip: "93.157.225.3"
     country: "RU"
     reverse: "ns.moskvoretskoe.ru"
     provider: "MOSKVORETSKOE-AS ZAO Moskvoretskoe"
-  - 
+  -
     ip: "66.182.208.5"
     country: "US"
     reverse: "cache1.1scom.net"
     provider: "MTL-19 - Millennium Telcom LLC"
-  - 
+  -
     ip: "82.204.186.250"
     provider: "MTS MTS OJSC"
     reverse: "mail.vs.ru"
     country: "RU"
-  - 
+  -
     ip: "83.242.140.10"
     provider: "MTS MTS OJSC"
     reverse: "rr1.comstar.ru"
     country: "RU"
-  - 
+  -
     ip: "194.54.148.129"
     country: "RU"
     reverse: "mx.mts.ru"
     provider: "MTSNET MTS OJSC"
-  - 
+  -
     ip: "134.48.1.32"
     country: "US"
     reverse: "dns1.mu.edu"
     provider: "MU-AS - Marquette University"
-  - 
+  -
     ip: "195.93.223.2"
     provider: "MULTIMEDIA-AS Multimedia Polska S.A."
     reverse: "ns1.csm.pl"
     country: "PL"
-  - 
+  -
     ip: "217.70.48.6"
     country: "PL"
     reverse: "info.zicom.pl"
     provider: "MULTIMEDIA-AS Multimedia Polska S.A."
-  - 
+  -
     ip: "217.70.48.20"
     provider: "MULTIMEDIA-AS Multimedia Polska S.A."
     reverse: "w3cache.zicom.pl"
     country: "PL"
-  - 
+  -
     ip: "94.30.127.6"
     country: "GB"
     reverse: "ns-01.core.the.uk.murphx.net"
     provider: "MURPHX-UK-AS Daisy Communications Ltd"
-  - 
+  -
     ip: "196.22.160.12"
     provider: "MWEB-10474"
     reverse: "jhbdns2.tiscali.co.za"
     country: "ZA"
-  - 
+  -
     ip: "196.2.45.101"
     country: "ZA"
     reverse: "hurricane.mweb.co.za"
     provider: "MWEB-12258"
-  - 
+  -
     ip: "200.56.224.11"
     country: "MX"
     reverse: "ns.marcatel.com.mx"
     provider: "Marcatel Com, S.A. de C.V."
-  - 
+  -
     ip: "200.66.96.1"
     provider: "Maxcom Telecomunicaciones, S.A.B. de C.V."
     reverse: "dns.maxcom.net.mx"
     country: "MX"
-  - 
+  -
     ip: "193.151.32.40"
     provider: "NACURA-AS nacura it-SERVICE GmbH & Co. KG"
     reverse: "ns1.nacura.de"
     country: "DE"
-  - 
+  -
     ip: "193.151.35.1"
     country: "DE"
     reverse: "gw1-in.comsult.net"
     provider: "NACURA-AS nacura it-SERVICE GmbH & Co. KG"
-  - 
-    ip: "216.8.179.50"
-    provider: "ND-CA-ASN - NEXT DIMENSION INC"
-    reverse: "ns1.fastpark.net"
-    country: "CA"
-  - 
+  -
     ip: "218.223.32.1"
     provider: "NDAC Global Network Core Co.,Ltd."
     reverse: "ns01.niigata-idc.ne.jp"
     country: "JP"
-  - 
+  -
     ip: "66.163.129.19"
     provider: "NDTELCO - NORTH DAKOTA TELEPHONE COMPANY"
     reverse: "ultra10.stellarnet.com"
     country: "US"
-  - 
+  -
     ip: "83.167.58.133"
     country: "FR"
     reverse: "ns1.fr.kddi.com"
     provider: "NEO-ASN Neo Telecoms S.A.S."
-  - 
+  -
     ip: "69.164.210.86"
     country: "US"
     reverse: "vpn.gilchrist.me"
     provider: "NET-ACCESS-CORP - Net Access Corporation"
-  - 
+  -
     ip: "81.173.201.34"
     provider: "NETCOLOGNE NetCologne GmbH"
     reverse: "ns1.net-design.net"
     country: "DE"
-  - 
+  -
     ip: "213.168.66.68"
     country: "DE"
     reverse: "ns2.net-design.net"
     provider: "NETCOLOGNE NetCologne GmbH"
-  - 
+  -
     ip: "80.69.192.10"
     provider: "NETCOM-KASSEL Netcom Kassel"
     reverse: "darkstar.netcomnetz.de"
     country: "DE"
-  - 
+  -
     ip: "37.221.193.195"
     country: "DE"
     reverse: "de2.godau.eu"
     provider: "NETCUP-AS netcup GmbH"
-  - 
+  -
     ip: "67.212.94.250"
     country: "CA"
     reverse: "67.212.94.250"
     provider: "NETELLIGENT - Netelligent Hosting Services Inc."
-  - 
+  -
     ip: "205.204.88.60"
     country: "CA"
     reverse: "84.blockaid.me"
     provider: "NETELLIGENT - Netelligent Hosting Services Inc."
-  - 
+  -
     ip: "89.222.201.202"
     provider: "NETORN-AS Netorn LLC"
     reverse: "ns2.netorn.ru"
     country: "RU"
-  - 
+  -
     ip: "81.17.2.171"
     country: "RU"
     reverse: "ns2.enforta.com"
     provider: "NETPROVODOV-AS OOO Company Tron"
-  - 
+  -
     ip: "212.43.137.10"
     provider: "NETSERV Autonomous System of Darest Informatic"
     reverse: "ns3.netserv.ch"
     country: "CH"
-  - 
+  -
     ip: "212.43.137.100"
     country: "CH"
     reverse: "ns4.netserv.ch"
     provider: "NETSERV Autonomous System of Darest Informatic"
-  - 
+  -
     ip: "193.41.252.146"
     provider: "NETWORK-TEAM-AS Network Team GmbH"
     reverse: "merkur.nw-team.de"
     country: "DE"
-  - 
+  -
     ip: "79.141.64.242"
     country: "RU"
     reverse: "ns.new-com.ru"
     provider: "NEWCOM-AS LLC _Santel_"
-  - 
+  -
     ip: "79.141.66.242"
     provider: "NEWCOM-AS LLC _Santel_"
     reverse: "ns1.new-com.ru"
     country: "RU"
-  - 
+  -
     ip: "207.69.188.172"
     provider: "NEWEDGENETS - New Edge Networks"
     reverse: "optns2.earthlink.net"
     country: "US"
-  - 
+  -
     ip: "207.69.188.184"
     country: "US"
     reverse: "rns0.earthlink.net"
     provider: "NEWEDGENETS - New Edge Networks"
-  - 
+  -
     ip: "207.69.188.188"
     provider: "NEWEDGENETS - New Edge Networks"
     reverse: "rns1.mcihispeed.net"
     country: "US"
-  - 
+  -
     ip: "207.69.188.189"
     country: "US"
     reverse: "rns2.mcihispeed.net"
     provider: "NEWEDGENETS - New Edge Networks"
-  - 
+  -
     ip: "207.217.77.82"
     country: "US"
     reverse: "do-not-use-rns2.earthlink.net"
     provider: "NEWEDGENETS - New Edge Networks"
-  - 
+  -
     ip: "207.217.120.83"
     provider: "NEWEDGENETS - New Edge Networks"
     reverse: "do-not-use-rns3.earthlink.net"
     country: "US"
-  - 
+  -
     ip: "209.86.63.237"
     country: "US"
     reverse: "rns-obtain.atl.sa.earthlink.net"
     provider: "NEWEDGENETS - New Edge Networks"
-  - 
+  -
     ip: "193.39.247.77"
     provider: "NG-UK-AS National Grid UK Ltd"
     reverse: "193.39.247.77"
     country: "GB"
-  - 
+  -
     ip: "193.39.247.205"
     country: "GB"
     reverse: "193.39.247.205"
     provider: "NG-UK-AS National Grid UK Ltd"
-  - 
+  -
     ip: "213.166.224.15"
     country: "DE"
     reverse: "core.niedermayr.de"
     provider: "NIEDERMAYR F.A.N.-Internet Service GmbH"
-  - 
+  -
     ip: "202.129.204.251"
     country: "TH"
     reverse: "ns1.topzone.biz"
     provider: "NIPA-AS-TH NIPA TECHNOLOGY CO., LTD"
-  - 
+  -
     ip: "209.212.30.143"
     provider: "NJ-STATEWIDE-LIBRARY-NETWORK - New Jersey State Library"
     reverse: "ns2.njsl.org"
     country: "US"
-  - 
+  -
     ip: "206.51.143.55"
     provider: "NKTC - NEW KNOXVILLE TELEPHONE COMPANY"
     reverse: "ns2.nktelco.net"
     country: "US"
-  - 
+  -
     ip: "83.97.97.2"
     country: "DK"
     reverse: "ns1.nmnet.dk"
     provider: "NMNET NM Net ApS"
-  - 
+  -
     ip: "83.97.97.3"
     provider: "NMNET NM Net ApS"
     reverse: "ns2.nmnet.dk"
     country: "DK"
-  - 
+  -
     ip: "195.189.130.1"
     country: "DK"
     reverse: "ns1.obox.dk"
     provider: "NMNET NM Net ApS"
-  - 
+  -
     ip: "217.72.1.2"
     country: "RU"
     reverse: "ns.nnt.ru"
     provider: "NNT-MOSCOW-AS Thyphone Communications LLC"
-  - 
+  -
     ip: "64.29.0.30"
     provider: "NO - Hilti Incorporated"
     reverse: "scatha.us.hilti.com"
     country: "US"
-  - 
+  -
     ip: "64.120.189.134"
     provider: "NOC - Network Operations Center Inc."
     reverse: "ns2.sitespot.net"
     country: "US"
-  - 
+  -
     ip: "184.82.223.18"
     country: "US"
     reverse: "184-82-223-18.static.hostnoc.net"
     provider: "NOC - Network Operations Center Inc."
-  - 
+  -
     ip: "83.166.174.20"
     provider: "NODE4-AS Node4 Limited"
     reverse: "mx1.navaho.co.uk"
     country: "GB"
-  - 
+  -
     ip: "192.78.147.2"
     country: "DE"
     reverse: "192.78.147.2"
     provider: "NORDAC-AS Capgemini Outsourcing Services GmbH"
-  - 
+  -
     ip: "192.78.147.3"
     provider: "NORDAC-AS Capgemini Outsourcing Services GmbH"
     reverse: "ns2.nordac.com"
     country: "DE"
-  - 
+  -
     ip: "91.200.170.235"
     provider: "NOSTRACOM-TELECOMUNICACIONES Nostracom Telecomunicaciones S.A."
     reverse: "91.200.170.235"
     country: "ES"
-  - 
+  -
     ip: "212.85.32.2"
     country: "ES"
     reverse: "ns1.nova.es"
     provider: "NOVA_INTERNET_AS12521 Nova Internet Network"
-  - 
+  -
     ip: "212.85.32.3"
     provider: "NOVA_INTERNET_AS12521 Nova Internet Network"
     reverse: "ns3.nova.es"
     country: "ES"
-  - 
+  -
     ip: "212.85.32.4"
     country: "ES"
     reverse: "mx.nova.es"
     provider: "NOVA_INTERNET_AS12521 Nova Internet Network"
-  - 
+  -
     ip: "208.70.158.229"
     country: "US"
     reverse: "hou-srv10.novolink.net"
     provider: "NOVOLINK - NovoLink Communications, Inc. - Houston"
-  - 
+  -
     ip: "80.250.189.13"
     country: "RU"
     reverse: "school.novsu.ac.ru"
     provider: "NOVSU-RUNNET The State Educational Institution of Higher Vocational Education _Yaroslav-the-Wise Novgorod State University_"
-  - 
+  -
     ip: "84.237.112.3"
     provider: "NSC Institute of Computational Technologies of SB RAS"
     reverse: "cvs.ikz.ru"
     country: "RU"
-  - 
+  -
     ip: "216.237.221.42"
     provider: "NSTELCO - North State Telephone Co."
     reverse: "dns3.nstel.com"
     country: "US"
-  - 
+  -
     ip: "79.141.81.250"
     country: "CH"
     reverse: "ns1.ntd.ch"
     provider: "NTD-AS NTD SA"
-  - 
+  -
     ip: "79.141.82.250"
     provider: "NTD-AS NTD SA"
     reverse: "ns2.ntd.ch"
     country: "CH"
-  - 
+  -
     ip: "79.141.83.250"
     country: "CH"
     reverse: "ns3.ntd.ch"
     provider: "NTD-AS NTD SA"
-  - 
+  -
     ip: "194.168.4.100"
     country: "GB"
     reverse: "cache1.service.virginmedia.net"
     provider: "NTL Virgin Media Limited"
-  - 
+  -
     ip: "94.199.234.1"
     provider: "NTL Virgin Media Limited"
     reverse: "ns1.hosting.imerja.com"
     country: "GB"
-  - 
+  -
     ip: "193.111.230.24"
     provider: "NTL Virgin Media Limited"
     reverse: "ns1.thenameservers.co.uk"
     country: "GB"
-  - 
+  -
     ip: "195.188.155.44"
     provider: "NTL Virgin Media Limited"
     reverse: "ns1.midlandinternet.net"
     country: "GB"
-  - 
+  -
     ip: "85.119.72.2"
     country: "RU"
     reverse: "www.ntsias.ru"
     provider: "NTSI-AS NTSI Telecom Ltd"
-  - 
+  -
     ip: "85.119.74.2"
     provider: "NTSI-AS NTSI Telecom Ltd"
     reverse: "ns.ntsi-telecom.ru"
     country: "RU"
-  - 
+  -
     ip: "61.120.156.179"
     country: "US"
     reverse: "61.120.156.179"
     provider: "NTT-COMMUNICATIONS-2914 - NTT America, Inc."
-  - 
+  -
     ip: "61.213.148.2"
     provider: "NTT-COMMUNICATIONS-2914 - NTT America, Inc."
     reverse: "ns1.haseko.co.jp"
     country: "US"
-  - 
+  -
     ip: "129.250.35.250"
     country: "US"
     reverse: "x.ns.gin.ntt.net"
     provider: "NTT-COMMUNICATIONS-2914 - NTT America, Inc."
-  - 
+  -
     ip: "129.250.35.251"
     provider: "NTT-COMMUNICATIONS-2914 - NTT America, Inc."
     reverse: "y.ns.gin.ntt.net"
     country: "US"
-  - 
+  -
     ip: "64.94.100.115"
     country: "US"
     reverse: "gatela.ns.alohadns.com"
     provider: "NUCLEARFALLOUT-LAX - Nuclearfallout Enterprises, Inc."
-  - 
+  -
     ip: "193.239.211.66"
     provider: "NUCLEUS Nucleus BVBA"
     reverse: "193-239-211-66.ant.nucleus.be"
     country: "BE"
-  - 
+  -
     ip: "193.239.211.67"
     country: "BE"
     reverse: "193-239-211-67.ant.nucleus.be"
     provider: "NUCLEUS Nucleus BVBA"
-  - 
+  -
     ip: "216.107.0.4"
     provider: "NUNETPA - NuNet Inc."
     reverse: "ns1.nricolo.com"
     country: "US"
-  - 
+  -
     ip: "209.88.198.133"
     provider: "NV-ASN 013 NetVision Ltd."
     reverse: "209.88.198.133"
     country: "IL"
-  - 
+  -
     ip: "194.206.126.253"
     provider: "NordNet"
     reverse: "name.nordnet.fr"
     country: "FR"
-  - 
+  -
     ip: "195.146.235.253"
     country: "FR"
     reverse: "name2.nordnet.fr"
     provider: "NordNet"
-  - 
+  -
     ip: "66.81.1.252"
     provider: "O1COMM - O1.com"
     reverse: "ns4.o1.com"
     country: "US"
-  - 
+  -
     ip: "62.40.32.33"
     country: "IE"
     reverse: "dns1.o2.ie"
     provider: "O2 Ireland"
-  - 
+  -
     ip: "62.40.32.34"
     provider: "O2 Ireland"
     reverse: "dns2.o2.ie"
     country: "IE"
-  - 
+  -
     ip: "157.134.160.1"
     country: "US"
     reverse: "ns4.wcnet.org"
     provider: "OARNET-AS - OARnet"
-  - 
+  -
     ip: "192.88.193.144"
     country: "US"
     reverse: "ns1.oar.net"
     provider: "OARNET-AS - OARnet"
-  - 
+  -
     ip: "192.88.195.10"
     provider: "OARNET-AS - OARnet"
     reverse: "ns2.oar.net"
     country: "US"
-  - 
+  -
     ip: "212.102.225.2"
     provider: "OBIS Oberberg-Online Informationssysteme GmbH"
     reverse: "ns.oberberg-online.de"
     country: "DE"
-  - 
+  -
     ip: "83.219.229.5"
     provider: "OBLCOM-AS JSC Oblcom"
     reverse: "mail.infotime.ru"
     country: "RU"
-  - 
+  -
     ip: "212.65.160.43"
     country: "CH"
     reverse: "mail.oblcom.ch"
     provider: "OBLCOMSW-AS Oblcom Swiss AG"
-  - 
+  -
     ip: "62.8.96.38"
     provider: "OBSL-AS TalkTalk Communications Limited"
     reverse: "res04.opal-solutions.com"
     country: "GB"
-  - 
+  -
     ip: "195.12.4.247"
     provider: "OBSL-AS TalkTalk Communications Limited"
     reverse: "res08.opal-solutions.com"
     country: "GB"
-  - 
+  -
     ip: "195.74.128.6"
     country: "GB"
     reverse: "res03.opal-solutions.com"
     provider: "OBSL-AS TalkTalk Communications Limited"
-  - 
+  -
     ip: "72.11.150.10"
     provider: "OC3-NETWORKS-AS-NUMBER Web Africa Proxy aut-num object"
     reverse: "72.11.150.10.static.quadranet.com"
     country: "US"
-  - 
+  -
     ip: "72.11.150.74"
     country: "US"
     reverse: "72.11.150.74.static.quadranet.com"
     provider: "OC3-NETWORKS-AS-NUMBER Web Africa Proxy aut-num object"
-  - 
+  -
     ip: "205.172.19.79"
     provider: "OCEANIC-CABLE - Oceanic Cable"
     reverse: "dns2.oceanic.net"
     country: "US"
-  - 
+  -
     ip: "60.32.112.42"
     country: "JP"
     reverse: "ns.daiwa-printing.co.jp"
     provider: "OCN NTT Communications Corporation"
-  - 
+  -
     ip: "61.207.9.4"
     provider: "OCN NTT Communications Corporation"
     reverse: "ns6-tk01.ocn.ad.jp"
     country: "JP"
-  - 
+  -
     ip: "61.208.115.242"
     country: "JP"
     reverse: "ns.wjc-news.co.jp"
     provider: "OCN NTT Communications Corporation"
-  - 
+  -
     ip: "203.139.160.19"
     provider: "OCN NTT Communications Corporation"
     reverse: "pns.ocn.ad.jp"
     country: "JP"
-  - 
+  -
     ip: "203.139.160.74"
     country: "JP"
     reverse: "ns-tk012.ocn.ad.jp"
     provider: "OCN NTT Communications Corporation"
-  - 
+  -
     ip: "203.139.161.37"
     provider: "OCN NTT Communications Corporation"
     reverse: "ns-os001.ocn.ad.jp"
     country: "JP"
-  - 
+  -
     ip: "210.162.254.226"
     country: "JP"
     reverse: "ns.koyamasteel.co.jp"
     provider: "OCN NTT Communications Corporation"
-  - 
+  -
     ip: "210.227.119.194"
     provider: "OCN NTT Communications Corporation"
     reverse: "ns.ccia.or.jp"
     country: "JP"
-  - 
+  -
     ip: "211.123.64.66"
     country: "JP"
     reverse: "dns.k-seitai.co.jp"
     provider: "OCN NTT Communications Corporation"
-  - 
+  -
     ip: "211.123.202.34"
     provider: "OCN NTT Communications Corporation"
     reverse: "ns.summitstore.co.jp"
     country: "JP"
-  - 
+  -
     ip: "218.44.242.98"
     country: "JP"
     reverse: "ns.amiya.co.jp"
     provider: "OCN NTT Communications Corporation"
-  - 
+  -
     ip: "219.166.188.186"
     country: "JP"
     reverse: "ns.city.fujimino.saitama.jp"
     provider: "OCN NTT Communications Corporation"
-  - 
+  -
     ip: "220.99.115.146"
     country: "JP"
     reverse: "ns.hiramatsu-mhp.or.jp"
     provider: "OCN NTT Communications Corporation"
-  - 
+  -
     ip: "220.110.17.109"
     provider: "OCN NTT Communications Corporation"
     reverse: "dns.edic.co.jp"
     country: "JP"
-  - 
+  -
     ip: "220.110.32.2"
     country: "JP"
     reverse: "220.110.32.2"
     provider: "OCN NTT Communications Corporation"
-  - 
+  -
     ip: "220.110.92.202"
     provider: "OCN NTT Communications Corporation"
     reverse: "ns.marine-onair.net"
     country: "JP"
-  - 
+  -
     ip: "220.110.172.234"
     country: "JP"
     reverse: "www.fgfc.jp"
     provider: "OCN NTT Communications Corporation"
-  - 
+  -
     ip: "221.186.115.98"
     country: "JP"
     reverse: "ns.tenryu-kogyo.co.jp"
     provider: "OCN NTT Communications Corporation"
-  - 
+  -
     ip: "221.186.164.66"
     provider: "OCN NTT Communications Corporation"
     reverse: "ns1.ee-datt.com"
     country: "JP"
-  - 
+  -
     ip: "221.186.252.130"
     country: "JP"
     reverse: "ns.onomichi.ed.jp"
     provider: "OCN NTT Communications Corporation"
-  - 
+  -
     ip: "222.151.241.10"
     provider: "OCN NTT Communications Corporation"
     reverse: "ns.meigan.co.jp"
     country: "JP"
-  - 
+  -
     ip: "143.90.130.39"
     country: "JP"
     reverse: "jns4.odn.ne.jp"
     provider: "ODN SOFTBANK TELECOM Corp."
-  - 
+  -
     ip: "143.90.130.165"
     provider: "ODN SOFTBANK TELECOM Corp."
     reverse: "ns5.odn.ne.jp"
     country: "JP"
-  - 
+  -
     ip: "143.90.130.166"
     country: "JP"
     reverse: "ns3.odn.ne.jp"
     provider: "ODN SOFTBANK TELECOM Corp."
-  - 
+  -
     ip: "165.76.4.2"
     provider: "ODN SOFTBANK TELECOM Corp."
     reverse: "ns.spin.ad.jp"
     country: "JP"
-  - 
+  -
     ip: "165.76.8.2"
     country: "JP"
     reverse: "ns.tokyo.spin.ad.jp"
     provider: "ODN SOFTBANK TELECOM Corp."
-  - 
+  -
     ip: "165.76.16.2"
     provider: "ODN SOFTBANK TELECOM Corp."
     reverse: "ns.tokyo.att.ne.jp"
     country: "JP"
-  - 
+  -
     ip: "62.152.168.253"
     country: "DE"
     reverse: "ns1.enweb.de"
     provider: "ODR-TKG-AS ODR Technologie Services GmbH"
-  - 
+  -
     ip: "62.152.176.131"
     provider: "ODR-TKG-AS ODR Technologie Services GmbH"
     reverse: "rabbit.eu.spectrumbrands.com"
     country: "DE"
-  - 
+  -
     ip: "62.152.177.87"
     country: "DE"
     reverse: "ns2.enweb.de"
     provider: "ODR-TKG-AS ODR Technologie Services GmbH"
-  - 
+  -
     ip: "209.143.0.10"
     country: "US"
     reverse: "primary.dns.bright.net"
     provider: "OHIOBRIGHTNET - Com Net, Inc."
-  - 
+  -
     ip: "209.143.22.182"
     provider: "OHIOBRIGHTNET - Com Net, Inc."
     reverse: "bacchus.bright.net"
     country: "US"
-  - 
+  -
     ip: "213.184.0.42"
     country: "TR"
     reverse: "dns1.uwm.edu.pl"
     provider: "OLMAN-EDU-AS OLMAN, Metropolitan Area Network (educational AS)"
-  - 
+  -
     ip: "213.184.0.50"
     provider: "OLMAN-EDU-AS OLMAN, Metropolitan Area Network (educational AS)"
     reverse: "zeus.uwm.edu.pl"
     country: "TR"
-  - 
+  -
     ip: "92.43.224.1"
     country: "ES"
     reverse: "eth0-1.sinatra.ono.omniaccess.com"
     provider: "OMNIACCESS-AS OmniAccess S.L."
-  - 
+  -
     ip: "193.243.148.3"
     country: "PL"
     reverse: "ns1.omnitec.pl"
     provider: "OMNITEC Omnitec Sp. z o.o."
-  - 
+  -
     ip: "193.243.149.3"
     provider: "OMNITEC Omnitec Sp. z o.o."
     reverse: "ns2.omnitec.pl"
     country: "PL"
-  - 
+  -
     ip: "212.227.39.54"
     country: "DE"
     reverse: "s15211061.onlinehome-server.info"
     provider: "ONEANDONE-AS 1&1 Internet AG"
-  - 
+  -
     ip: "208.48.253.106"
     country: "US"
     reverse: "ns1.onecleveland.org"
     provider: "ONECLEVELAND - OneCleveland"
-  - 
+  -
     ip: "89.140.140.8"
     provider: "ONO-AS Cableuropa - ONO"
     reverse: "ns.saimanet.net"
     country: "ES"
-  - 
+  -
     ip: "89.140.140.9"
     country: "ES"
     reverse: "ns2.saimanet.net"
     provider: "ONO-AS Cableuropa - ONO"
-  - 
+  -
     ip: "91.207.136.36"
     country: "RU"
     reverse: "ns.ooonet.ru"
     provider: "OOOSET-AS OOO SET"
-  - 
+  -
     ip: "208.67.222.222"
     country: "US"
     reverse: "resolver1.opendns.com"
     provider: "OPENDNS - OpenDNS, LLC"
-  - 
+  -
     ip: "208.67.220.220"
     country: "US"
     reverse: "resolver2.opendns.com"
     provider: "OPENDNS - OpenDNS, LLC"
-  - 
+  -
     ip: "208.67.220.123"
     provider: "OPENDNS - OpenDNS, LLC"
     reverse: "resolver2-fs.opendns.com"
     country: "US"
-  - 
+  -
     ip: "208.67.220.222"
     provider: "OPENDNS - OpenDNS, LLC"
     reverse: "resolver4.opendns.com"
     country: "US"
-  - 
+  -
     ip: "208.67.222.123"
     country: "US"
     reverse: "resolver1-fs.opendns.com"
     provider: "OPENDNS - OpenDNS, LLC"
-  - 
+  -
     ip: "208.67.222.220"
     provider: "OPENDNS - OpenDNS, LLC"
     reverse: "resolver3.opendns.com"
     country: "US"
-  - 
+  -
     ip: "91.195.128.12"
     provider: "OPENSYSTEMS-AS Open Systems Ltd."
     reverse: "ns2.osystems.ru"
     country: "RU"
-  - 
+  -
     ip: "91.195.129.3"
     country: "RU"
     reverse: "ns3.osystems.ru"
     provider: "OPENSYSTEMS-AS Open Systems Ltd."
-  - 
+  -
     ip: "217.173.198.2"
     country: "PL"
     reverse: "polo.po.opole.pl"
     provider: "OPOLMAN-AS-EDU Opole University"
-  - 
+  -
     ip: "80.250.182.2"
     provider: "OPTICALNET-AS JSC Avantel, North-West branch"
     reverse: "mail.opnet.spb.ru"
     country: "RU"
-  - 
+  -
     ip: "80.88.192.2"
     country: "GB"
     reverse: "ns0.ns0.net"
     provider: "ORBITAL-ASN OrbitalNet Ltd"
-  - 
+  -
     ip: "80.88.200.119"
     provider: "ORBITAL-ASN OrbitalNet Ltd"
     reverse: "charlie.orbitalnet.co.uk"
     country: "GB"
-  - 
+  -
     ip: "80.88.214.11"
     country: "GB"
     reverse: "ns1.orbcp3.co.uk"
     provider: "ORBITAL-ASN OrbitalNet Ltd"
-  - 
+  -
     ip: "80.88.214.36"
     provider: "ORBITAL-ASN OrbitalNet Ltd"
     reverse: "ns1.osirissystemsdns.co.uk"
     country: "GB"
-  - 
+  -
     ip: "80.88.214.51"
     country: "GB"
     reverse: "ns1.orbcp4.co.uk"
     provider: "ORBITAL-ASN OrbitalNet Ltd"
-  - 
+  -
     ip: "80.88.215.146"
     provider: "ORBITAL-ASN OrbitalNet Ltd"
     reverse: "ns1.orbcp5.co.uk"
     country: "GB"
-  - 
+  -
     ip: "94.230.34.131"
     country: "RU"
     reverse: "ns-pri.oskolnet.ru"
     provider: "OSKOLNET-AS Closed Joint Stock Company Oskolnet"
-  - 
+  -
     ip: "94.230.40.2"
     provider: "OSKOLNET-AS Closed Joint Stock Company Oskolnet"
     reverse: "mail.oskolnet.ru"
     country: "RU"
-  - 
+  -
     ip: "212.114.93.186"
     provider: "OSN OSN Online Service Nuernberg GmbH"
     reverse: "dns3.dacor.de"
     country: "DE"
-  - 
+  -
     ip: "91.207.164.4"
     provider: "OSS-URAL-AS OSS Ural Ltd."
     reverse: "ns1.ossural.ru"
     country: "RU"
-  - 
+  -
     ip: "176.31.189.137"
     provider: "OVH OVH Systems"
     reverse: "137.ip-176-31-189.eu"
     country: "FR"
-  - 
+  -
     ip: "195.60.164.37"
     country: "FR"
     reverse: "ns2.o1nk.net"
     provider: "OVH OVH Systems"
-  - 
+  -
     ip: "195.60.164.69"
     provider: "OVH OVH Systems"
     reverse: "ns1.o1nk.net"
     country: "FR"
-  - 
+  -
     ip: "213.251.133.164"
     provider: "OVH OVH Systems"
     reverse: "ks31884.kimsufi.com"
     country: "FR"
-  - 
+  -
     ip: "200.57.2.108"
     provider: "Operbes, S.A. de C.V."
     reverse: "dns1.bestel.com.mx"
     country: "MX"
-  - 
+  -
     ip: "200.57.7.61"
     country: "MX"
     reverse: "dns2.bestel.com.mx"
     provider: "Operbes, S.A. de C.V."
-  - 
+  -
     ip: "209.68.1.11"
     provider: "PAIR-NETWORKS - pair Networks"
     reverse: "pri.pair.com"
     country: "US"
-  - 
+  -
     ip: "91.98.48.20"
     provider: "PARSONLINE PARSONLINE Autonomous System"
     reverse: "91.98.48.20.pol.ir"
     country: "IR"
-  - 
+  -
     ip: "157.99.64.64"
     country: "FR"
     reverse: "ns1.pasteur.fr"
     provider: "PASTEUR-AS Institut Pasteur"
-  - 
+  -
     ip: "157.99.64.65"
     provider: "PASTEUR-AS Institut Pasteur"
     reverse: "ns0.pasteur.fr"
     country: "FR"
-  - 
+  -
     ip: "209.250.128.6"
     country: "CA"
     reverse: "typhon.tor.pathcom.com"
     provider: "PATHWAY - Pathway Communications"
-  - 
+  -
     ip: "209.152.32.26"
     country: "US"
     reverse: "dns1.sya.pcc.edu"
     provider: "PCCNET - Portland Community College"
-  - 
+  -
     ip: "209.152.61.178"
     provider: "PCCNET - Portland Community College"
     reverse: "ns1.pcc.edu"
     country: "US"
-  - 
+  -
     ip: "69.64.224.67"
     provider: "PDX - PORTLAND INTERNETWORKS"
     reverse: "sulfur.pdx.net"
     country: "US"
-  - 
+  -
     ip: "69.28.239.8"
     provider: "PEER1 - Peer 1 Network Inc."
     reverse: "ns1.electronicbox.net"
     country: "US"
-  - 
+  -
     ip: "69.28.239.9"
     country: "US"
     reverse: "ns2.electronicbox.net"
     provider: "PEER1 - Peer 1 Network Inc."
-  - 
+  -
     ip: "74.222.0.8"
     provider: "PERFECT-INTERNATIONAL - Perfect International, Inc"
     reverse: "server1.vrtservers.net"
     country: "US"
-  - 
+  -
     ip: "210.23.129.34"
     country: "AU"
     reverse: "ns2.pacific.net.au"
     provider: "PI-AU Pacific Internet (Australia) Pty Ltd"
-  - 
+  -
     ip: "46.161.32.3"
     provider: "PIN-AS Petersburg Internet Network LLC"
     reverse: "ns1.nx0.ru"
     country: "RU"
-  - 
+  -
     ip: "194.11.20.40"
     provider: "PIN-AS Petersburg Internet Network LLC"
     reverse: "mail.pinspb.ru"
     country: "RU"
-  - 
+  -
     ip: "195.2.240.137"
     provider: "PIN-AS Petersburg Internet Network LLC"
     reverse: "195.2.240.137"
     country: "RU"
-  - 
+  -
     ip: "194.64.31.3"
     provider: "PIRONETNDH-AS PIRONET NDH AG"
     reverse: "dns02.pironet-ndh.com"
     country: "DE"
-  - 
+  -
     ip: "195.94.88.254"
     country: "DE"
     reverse: "dns01.pironet-ndh.com"
     provider: "PIRONETNDH-AS PIRONET NDH AG"
-  - 
+  -
     ip: "195.94.90.10"
     provider: "PIRONETNDH-AS PIRONET NDH AG"
     reverse: "dns03.pironet-ndh.com"
     country: "DE"
-  - 
+  -
     ip: "212.106.138.4"
     country: "PL"
     reverse: "zion.ux.com.pl"
     provider: "PIRXNET-AS PirxNet Grzegorz Bialas"
-  - 
+  -
     ip: "89.191.149.2"
     country: "PL"
     reverse: "dns1.tvkablowa.com.pl"
     provider: "PL-BYDMAN-COM Commercial Users"
-  - 
+  -
     ip: "217.153.122.251"
     provider: "PL-TSYSTEMSPL T-SYSTEMS Sp. z o.o."
     reverse: "ns1.t-systems.com.pl"
     country: "PL"
-  - 
+  -
     ip: "213.83.52.2"
     country: "DE"
     reverse: "janus.xmn.de"
     provider: "PLUSLINE Plus.Line AG"
-  - 
+  -
     ip: "62.75.224.95"
     provider: "PLUSSERVER-AS intergenia AG"
     reverse: "prag010.startdedicated.com"
     country: "DE"
-  - 
+  -
     ip: "85.25.11.44"
     country: "DE"
     reverse: "lima221.server4you.de"
     provider: "PLUSSERVER-AS intergenia AG"
-  - 
+  -
     ip: "91.202.41.181"
     country: "DE"
     reverse: "cns01.plutex.de"
     provider: "PLUTEX PLUTEX GmbH"
-  - 
+  -
     ip: "217.27.240.20"
     provider: "POBOX-AS POBox Hosting Limited"
     reverse: "nscache0.pobox.co.uk"
     country: "GB"
-  - 
+  -
     ip: "217.151.0.50"
     provider: "POLIRIS-AS POLIRIS"
     reverse: "ns.poliris.net"
     country: "FR"
-  - 
+  -
     ip: "217.151.0.195"
     country: "FR"
     reverse: "ns2-new.poliris.net"
     provider: "POLIRIS-AS POLIRIS"
-  - 
+  -
     ip: "212.79.54.6"
     country: "DE"
     reverse: "212.79.54.6"
     provider: "POP pop-interactive GmbH"
-  - 
+  -
     ip: "150.254.158.149"
     country: "PL"
     reverse: "nsy.wskiz.edu"
     provider: "POZMAN POZMAN-EDU"
-  - 
+  -
     ip: "150.254.158.234"
     provider: "POZMAN POZMAN-EDU"
     reverse: "nsx.wskiz.edu"
     country: "PL"
-  - 
+  -
     ip: "212.126.5.34"
     provider: "POZMAN-COM POZMAN-COM"
     reverse: "best.best.net.pl"
     country: "PL"
-  - 
+  -
     ip: "195.20.3.2"
     provider: "PP-AS Peter Pan sp. z o.o."
     reverse: "ns2.pp.com.pl"
     country: "PL"
-  - 
+  -
     ip: "91.209.108.17"
     country: "ES"
     reverse: "ns2.optyma.com"
     provider: "PPI-AS Proveedores de Presencia en Internet S.L."
-  - 
+  -
     ip: "193.141.101.33"
     provider: "PPP-AS Pelikan & Partner"
     reverse: "mail.ppp.de"
     country: "DE"
-  - 
+  -
     ip: "212.18.80.8"
     provider: "PPP-AS Pelikan & Partner"
     reverse: "mail.ppp.net"
     country: "DE"
-  - 
+  -
     ip: "91.211.63.254"
     country: "RU"
     reverse: "91.211.63.254"
     provider: "PRAKTIKA-AS Praktika Ltd."
-  - 
+  -
     ip: "64.72.224.34"
     country: "CA"
     reverse: "m1.comm100email9.com"
     provider: "PRIMUS-AS6407 - Primus Telecommunications Canada Inc."
-  - 
+  -
     ip: "209.90.160.222"
     provider: "PRIMUS-AS6407 - Primus Telecommunications Canada Inc."
     reverse: "ns2.primus.ca"
     country: "CA"
-  - 
+  -
     ip: "216.254.141.2"
     provider: "PRIMUS-AS6407 - Primus Telecommunications Canada Inc."
     reverse: "ns1.primus.ca"
     country: "CA"
-  - 
+  -
     ip: "216.254.141.13"
     country: "CA"
     reverse: "dnscache1.tor.primus.ca"
     provider: "PRIMUS-AS6407 - Primus Telecommunications Canada Inc."
-  - 
+  -
     ip: "206.124.1.254"
     country: "US"
     reverse: "ns-3.dimensional.com"
     provider: "PRIVATEI - privateI, LLC"
-  - 
+  -
     ip: "82.96.65.2"
     provider: "PROBENETWORKS-AS Probe Networks"
     reverse: "trance.probe-networks.de"
     country: "DE"
-  - 
+  -
     ip: "82.96.81.10"
     country: "DE"
     reverse: "ns1.ec-c.net"
     provider: "PROBENETWORKS-AS Probe Networks"
-  - 
+  -
     ip: "82.96.86.20"
     provider: "PROBENETWORKS-AS Probe Networks"
     reverse: "82.96.86.20"
     country: "DE"
-  - 
+  -
     ip: "78.140.192.18"
     provider: "PROMETEY Prometey Ltd. Autonomous System"
     reverse: "mail.kanrit.net"
     country: "RU"
-  - 
+  -
     ip: "78.140.193.18"
     country: "RU"
     reverse: "ns2.kanrit.net"
     provider: "PROMETEY Prometey Ltd. Autonomous System"
-  - 
+  -
     ip: "85.235.192.2"
     country: "RU"
     reverse: "ns1.ptspb.ru"
     provider: "PROMETEY Prometey Ltd. Autonomous System"
-  - 
+  -
     ip: "85.235.193.2"
     provider: "PROMETEY Prometey Ltd. Autonomous System"
     reverse: "ns2.ptspb.ru"
     country: "RU"
-  - 
+  -
     ip: "85.235.193.98"
     country: "RU"
     reverse: "mail.v7site.ru"
     provider: "PROMETEY Prometey Ltd. Autonomous System"
-  - 
+  -
     ip: "85.235.199.199"
     provider: "PROMETEY Prometey Ltd. Autonomous System"
     reverse: "ns.rustest.spb.ru"
     country: "RU"
-  - 
+  -
     ip: "95.171.192.7"
     provider: "PROTONET-AS PROTONET Adrian Ludyga"
     reverse: "dns.protonet.pl"
     country: "PL"
-  - 
+  -
     ip: "193.239.59.253"
     country: "PL"
     reverse: "dns.korbank.pl"
     provider: "PROVIDER-WROCLAW Korbank sp. z o.o."
-  - 
+  -
     ip: "78.24.40.2"
     provider: "PRTNET-AS LTD Pokrovsky radiotelefon"
     reverse: "mail.prtcom.ru"
     country: "RU"
-  - 
+  -
     ip: "91.204.136.6"
     provider: "PSKOVLINE-AS Pskovline Ltd."
     reverse: "mail.pskovline.ru"
     country: "RU"
-  - 
+  -
     ip: "91.204.139.6"
     country: "RU"
     reverse: "ns2.pskovline.ru"
     provider: "PSKOVLINE-AS Pskovline Ltd."
-  - 
+  -
     ip: "195.19.162.246"
     country: "RU"
     reverse: "serv4.pstu.ru"
     provider: "PSTU-AS State Educational Institution of Higher Professional Education _Perm State Technical University_"
-  - 
+  -
     ip: "194.29.152.5"
     provider: "PW-NET Politechnika Warszawska"
     reverse: "siwy.il.pw.edu.pl"
     country: "PL"
-  - 
+  -
     ip: "194.29.153.5"
     country: "PL"
     reverse: "siwy.il.pw.edu.pl"
     provider: "PW-NET Politechnika Warszawska"
-  - 
+  -
     ip: "120.50.44.141"
     provider: "QALA-SG-AP M1 CONNECT PTE. LTD."
     reverse: "141.44.50.120.static.idc.qala.com.sg"
     country: "SG"
-  - 
+  -
     ip: "87.193.157.211"
     provider: "QSC-1 QSC AG"
     reverse: "mail.hcom.de"
     country: "DE"
-  - 
+  -
     ip: "80.190.139.6"
     country: "DE"
     reverse: "ns1.netlantic.de"
     provider: "QSC-AG-IPX QSC AG / ehem. IP Exchange GmbH"
-  - 
+  -
     ip: "80.190.200.10"
     provider: "QSC-AG-IPX QSC AG / ehem. IP Exchange GmbH"
     reverse: "elwood.regiogate.net"
     country: "DE"
-  - 
+  -
     ip: "195.234.230.67"
     provider: "QUALITYHOSTING-AS QualityHosting AG"
     reverse: "ns0.iquer.net"
     country: "DE"
-  - 
+  -
     ip: "213.60.244.3"
     provider: "R Cable y Telecomunicaciones Galicia, S.A."
     reverse: "int-static-244-3.ptg.es"
     country: "ES"
-  - 
+  -
     ip: "91.205.128.3"
     provider: "R-LINE-AS R-Line Ltd."
     reverse: "ns2.r-line.ru"
     country: "RU"
-  - 
+  -
     ip: "81.88.112.3"
     provider: "RA-TELECOM-AS JSC _AKADO-Stolitsa_"
     reverse: "h81-88-112-3.rev.domonet.ru"
     country: "RU"
-  - 
+  -
     ip: "66.163.0.161"
     provider: "RADIANT-TORONTO - Radiant Communications Canada Ltd."
     reverse: "66-163-0-161.ip.tor.radiant.net"
     country: "CA"
-  - 
+  -
     ip: "66.163.0.173"
     country: "CA"
     reverse: "66-163-0-173.ip.tor.radiant.net"
     provider: "RADIANT-TORONTO - Radiant Communications Canada Ltd."
-  - 
+  -
     ip: "216.21.128.22"
     country: "CA"
     reverse: "dns1.van.radiant.net"
     provider: "RADIANT-VANCOUVER - Radiant Communications Ltd."
-  - 
+  -
     ip: "216.21.129.22"
     provider: "RADIANT-VANCOUVER - Radiant Communications Ltd."
     reverse: "dns2.van.radiant.net"
     country: "CA"
-  - 
+  -
     ip: "194.67.74.2"
     country: "EU"
     reverse: "ugw.inr.troitsk.ru"
     provider: "RADIO-MSU RADIO-MSU"
-  - 
+  -
     ip: "91.206.72.2"
     provider: "RADIOPAGE-T-AS RadioPage-T OJSC."
     reverse: "mail.tulatt.ru"
     country: "RU"
-  - 
+  -
     ip: "195.66.116.101"
     provider: "RAFAKO-RACIBORZ-AS Fabryka Kotlow RAFAKO SA"
     reverse: "dns1.denko.com.pl"
     country: "PL"
-  - 
+  -
     ip: "72.2.10.2"
     provider: "RAINYDAYSOFTWARECORP - Rainy Day Software Corp."
     reverse: "ns2.voyageur.coop"
     country: "CA"
-  - 
+  -
     ip: "193.111.144.161"
     country: "PL"
     reverse: "prsrv2.uthrad.pl"
     provider: "RAMAN Politechnika Radomska Im.Kazimierza Pulaskiego"
-  - 
+  -
     ip: "195.158.239.4"
     country: "RU"
     reverse: "ns.rantcom.ru"
     provider: "RANT-AS ZAO Republic Joint-stock Independent Telecompany"
-  - 
+  -
     ip: "66.250.192.11"
     provider: "RAPIDDSL--WIRELESS - RapidDSL & Wireless"
     reverse: "ns1.rapiddsl.net"
     country: "US"
-  - 
+  -
     ip: "205.151.69.200"
     country: "CA"
     reverse: "ns1.cgocable.ca"
     provider: "RAPIDUS - COGECO Cable Canada Inc."
-  - 
+  -
     ip: "216.131.94.5"
     country: "US"
     reverse: "ns1.oakweb.com"
     provider: "RBLHST - Reliablehosting.com"
-  - 
+  -
     ip: "194.169.203.3"
     country: "FR"
     reverse: "backup.rbs.fr"
     provider: "RBSNET READY BUSINESS SYSTEM"
-  - 
+  -
     ip: "207.172.3.9"
     provider: "RCN-AS - RCN"
     reverse: "ns2.dns.rcn.net"
     country: "US"
-  - 
+  -
     ip: "207.172.11.72"
     country: "US"
     reverse: "watchmen.dns.rcn.net"
     provider: "RCN-AS - RCN"
-  - 
+  -
     ip: "207.172.11.73"
     provider: "RCN-AS - RCN"
     reverse: "neomen.dns.rcn.net"
     country: "US"
-  - 
+  -
     ip: "208.59.89.4"
     provider: "RCN-AS - RCN"
     reverse: "milk.dns.rcn.net"
     country: "US"
-  - 
+  -
     ip: "208.59.89.20"
     country: "US"
     reverse: "groo.dns.rcn.net"
     provider: "RCN-AS - RCN"
-  - 
+  -
     ip: "208.59.89.21"
     provider: "RCN-AS - RCN"
     reverse: "mortis.dns.rcn.net"
     country: "US"
-  - 
+  -
     ip: "208.59.247.45"
     country: "US"
     reverse: "ns2.dns.rcn.net"
     provider: "RCN-AS - RCN"
-  - 
+  -
     ip: "208.59.247.46"
     provider: "RCN-AS - RCN"
     reverse: "ns1.dns.rcn.net"
     country: "US"
-  - 
+  -
     ip: "89.207.74.37"
     country: "RU"
     reverse: "ns.kirovcity.ru"
     provider: "RELAX-AS JSC _Relax_"
-  - 
+  -
     ip: "66.7.142.78"
     provider: "RELIANCEGLOBALCOM - Reliance Globalcom Services, Inc"
     reverse: "dca001dn01.yipes.com"
     country: "US"
-  - 
+  -
     ip: "66.7.160.122"
     country: "US"
     reverse: "66.7.160.122"
     provider: "RELIANCEGLOBALCOM - Reliance Globalcom Services, Inc"
-  - 
+  -
     ip: "209.213.196.218"
     provider: "RELIANCEGLOBALCOM - Reliance Globalcom Services, Inc"
     reverse: "eth0.sfo001dn01.yipes.com"
     country: "US"
-  - 
+  -
     ip: "209.213.223.18"
     country: "US"
     reverse: "eth0.pal001dn01.yipes.com"
     provider: "RELIANCEGLOBALCOM - Reliance Globalcom Services, Inc"
-  - 
+  -
     ip: "91.196.8.2"
     provider: "RES-PL RES.PL ISP S.C."
     reverse: "dns1.res.pl"
     country: "PL"
-  - 
+  -
     ip: "91.123.160.5"
     provider: "RESETNET-AS MNI Telecom S.A."
     reverse: "91-123-160-5.lublin.hypnet.pl"
     country: "PL"
-  - 
+  -
     ip: "91.123.160.9"
     country: "PL"
     reverse: "ns1.resetnet.pl"
     provider: "RESETNET-AS MNI Telecom S.A."
-  - 
+  -
     ip: "195.13.38.3"
     country: "PL"
     reverse: "dns2.retsat1.com.pl"
     provider: "RETSAT STK Retsat1"
-  - 
+  -
     ip: "209.97.224.3"
     country: "US"
     reverse: "ns2.revealsystems.net"
     provider: "REVEAL - REVEAL SYSTEMS INC"
-  - 
+  -
     ip: "213.178.0.33"
     country: "DE"
     reverse: "ns.imsc.net"
     provider: "RIPE riconet GmbH"
-  - 
+  -
     ip: "213.178.2.23"
     provider: "RIPE riconet GmbH"
     reverse: "ns01.si.riconnect.de"
     country: "DE"
-  - 
+  -
     ip: "64.233.128.10"
     country: "US"
     reverse: "ns1.ritternet.com"
     provider: "RITTERNET - Ritter Communications, Inc."
-  - 
+  -
     ip: "64.233.128.11"
     provider: "RITTERNET - Ritter Communications, Inc."
     reverse: "ns2.ritternet.com"
     country: "US"
-  - 
+  -
     ip: "194.172.160.4"
     provider: "RITTERNET Baumann Technologie GmbH"
     reverse: "mci004.btnet.de"
     country: "DE"
-  - 
+  -
     ip: "217.22.172.10"
     provider: "ROILCOM-AS ROILCOM LTD"
     reverse: "ns.nica.ru"
     country: "RU"
-  - 
+  -
     ip: "109.207.55.2"
     provider: "RONUS-AS PE RONUS Beata Polrolniczak"
     reverse: "ns1.ronus.pl"
     country: "PL"
-  - 
+  -
     ip: "109.207.55.3"
     country: "PL"
     reverse: "ns2.ronus.pl"
     provider: "RONUS-AS PE RONUS Beata Polrolniczak"
-  - 
+  -
     ip: "62.217.164.1"
     country: "RU"
     reverse: "62.217.164.1"
     provider: "ROOTELECOM ROOTelecom Autonomous System"
-  - 
+  -
     ip: "188.128.22.2"
     provider: "ROSTELECOM-AS OJSC Rostelecom"
     reverse: "ns2.usla.ru"
     country: "RU"
-  - 
+  -
     ip: "82.179.32.4"
     country: "RU"
     reverse: "ns.seun.ru"
     provider: "RRC-AS Federal State Educational Institution of Higher Professional Education _Saratov state Socio-Economic University_"
-  - 
+  -
     ip: "80.93.177.182"
     country: "RU"
     reverse: "ns1.rsspnet.ru"
     provider: "RSSP-AS OOO Lira-S"
-  - 
+  -
     ip: "91.211.125.125"
     provider: "RTC-ORENBURG-AS CJSC _Comstar-Regions_"
     reverse: "ns1.itrtc.ru"
     country: "RU"
-  - 
+  -
     ip: "91.211.127.125"
     country: "RU"
     reverse: "91-211-127-125.bz.comstar.itrtc.ru"
     provider: "RTC-ORENBURG-AS CJSC _Comstar-Regions_"
-  - 
+  -
     ip: "195.161.115.3"
     country: "RU"
     reverse: "ns3.webdesk.ru"
     provider: "RTCOMM-AS OJSC RTComm.RU"
-  - 
+  -
     ip: "195.69.65.98"
     country: "RU"
     reverse: "hosting.d-v.ru"
     provider: "RU-DINET-F1 _DiSat_ Ltd."
-  - 
+  -
     ip: "212.41.3.147"
     provider: "RU-KTS-AS Krastelecomservice Ltd."
     reverse: "212.41.3.147"
     country: "RU"
-  - 
+  -
     ip: "62.148.228.2"
     country: "RU"
     reverse: "ns.vega-int.ru"
     provider: "RU-SURNET OJSC Rostelecom"
-  - 
+  -
     ip: "212.57.190.166"
     country: "RU"
     reverse: "host.mpautina.ru"
     provider: "RU-SURNET OJSC Rostelecom"
-  - 
+  -
     ip: "194.85.32.18"
     provider: "RUNNET State Institute of Information Technologies and"
     reverse: "ns.runnet.ru"
     country: "RU"
-  - 
+  -
     ip: "194.226.211.11"
     country: "RU"
     reverse: "ns.herzen.spb.ru"
     provider: "RUNNET State Institute of Information Technologies and"
-  - 
+  -
     ip: "195.209.228.37"
     provider: "RUNNET State Institute of Information Technologies and"
     reverse: "ns2.utelcom.ru"
     country: "RU"
-  - 
+  -
     ip: "195.209.229.37"
     country: "RU"
     reverse: "ns1.utelcom.ru"
     provider: "RUNNET State Institute of Information Technologies and"
-  - 
+  -
     ip: "80.81.208.146"
     country: "RU"
     reverse: "exten.d-v.ru"
     provider: "RUSAT-AS AS a Satellite Teleport RuSat"
-  - 
+  -
     ip: "194.85.100.2"
     country: "RU"
     reverse: "ns1.odu.neva.ru"
     provider: "RUSNET-AS _NPO RUSnet_"
-  - 
+  -
     ip: "194.85.100.32"
     provider: "RUSNET-AS _NPO RUSnet_"
     reverse: "ns0.odusz.so-cdu.ru"
     country: "RU"
-  - 
+  -
     ip: "88.147.158.1"
     country: "RU"
     reverse: "balakovo.san.ru"
     provider: "SAN-AS OJSC Rostelecom"
-  - 
+  -
     ip: "213.164.38.66"
     provider: "SATEC SATEC AS"
     reverse: "maruja.satec.es"
     country: "DE"
-  - 
+  -
     ip: "217.159.0.17"
     country: "DE"
     reverse: "dns.satlynx.net"
     provider: "SATLYNX_GMBH Signalhorn Trusted Networks GmbH"
-  - 
+  -
     ip: "178.161.146.10"
     provider: "SATURN-R-AS OOO Saturn-R"
     reverse: "178.161.146.10.ipn.v4.saturn-internet.ru"
     country: "RU"
-  - 
+  -
     ip: "198.83.19.241"
     country: "US"
     reverse: "ns3.prodigy.net"
     provider: "SBIS-AS AS for SBIS-AS"
-  - 
+  -
     ip: "198.83.19.244"
     country: "US"
     reverse: "ns4.prodigy.net"
     provider: "SBIS-AS AS for SBIS-AS"
-  - 
+  -
     ip: "207.115.59.241"
     country: "US"
     reverse: "nothing.attdns.com"
     provider: "SBIS-AS AS for SBIS-AS"
-  - 
+  -
     ip: "151.164.1.8"
     country: "US"
     reverse: "dns1.rcsntx.sbcglobal.net"
     provider: "SBIS-AS AS for SBIS-AS"
-  - 
+  -
     ip: "84.20.32.130"
     provider: "SCHEFER Schefer AG, Switzerland"
     reverse: "ns1.scheferag.ch"
     country: "CH"
-  - 
+  -
     ip: "72.51.175.10"
     provider: "SCRR-10796 - Time Warner Cable Internet LLC"
     reverse: "dns1.newwavecomm.net"
     country: "US"
-  - 
+  -
     ip: "72.51.175.11"
     country: "US"
     reverse: "dns2.newwavecomm.net"
     provider: "SCRR-10796 - Time Warner Cable Internet LLC"
-  - 
+  -
     ip: "68.68.167.9"
     country: "US"
     reverse: "cache1.felpsis.net"
     provider: "SCRR-11427 - Time Warner Cable Internet LLC"
-  - 
+  -
     ip: "195.137.246.17"
     country: "PL"
     reverse: "ns2.stn.pl"
     provider: "SELTELECOM-NET Sel Telecom S.A."
-  - 
+  -
     ip: "195.137.247.17"
     provider: "SELTELECOM-NET Sel Telecom S.A."
     reverse: "ns1.stn.pl"
     country: "PL"
-  - 
+  -
     ip: "216.93.191.228"
     country: "US"
     reverse: "cache01.ns.witopia.net"
     provider: "SERVEPATH - GoGrid, LLC"
-  - 
+  -
     ip: "65.210.29.34"
     provider: "SERVICEARGOS - SERVICE ARGOS INC"
     reverse: "dns1.argosinc.com"
     country: "US"
-  - 
+  -
     ip: "84.232.1.100"
     country: "ES"
     reverse: "ns1.servihosting.com"
     provider: "SERVIHOSTING-AS ServiHosting Networks S.L."
-  - 
+  -
     ip: "84.232.1.101"
     provider: "SERVIHOSTING-AS ServiHosting Networks S.L."
     reverse: "ns2.servihosting.com"
     country: "ES"
-  - 
+  -
     ip: "213.129.120.6"
     country: "RU"
     reverse: "mail-r.serw.ru"
     provider: "SETTC South-East Transtelecom Joint Stock Co."
-  - 
+  -
     ip: "217.148.0.17"
     provider: "SHLINK-CH-AS my-ch.net Autonomous System"
     reverse: "ns2.my-ch.net"
     country: "CH"
-  - 
+  -
     ip: "193.169.0.3"
     country: "RU"
     reverse: "ns.skysib.com"
     provider: "SIBCOM-AS Sibcom Ltd"
-  - 
+  -
     ip: "193.169.1.250"
     provider: "SIBCOM-AS Sibcom Ltd"
     reverse: "ns1.skysib.com"
     country: "RU"
-  - 
+  -
     ip: "213.128.216.115"
     provider: "SIBINTEK-VORONEZH-AS Siberian Internet Company"
     reverse: "ns.vfsibintek.ru"
     country: "RU"
-  - 
+  -
     ip: "212.20.0.126"
     country: "RU"
     reverse: "online.nsk.su"
     provider: "SIBIRTELECOM-AS OJSC Rostelecom"
-  - 
+  -
     ip: "195.158.250.193"
     provider: "SIBLINE-AS Sibline Ltd."
     reverse: "ns.sibline.net"
     country: "RU"
-  - 
+  -
     ip: "212.106.154.2"
     provider: "SILWEB-AS-COM Silesian University of Technology, Computer Centre"
     reverse: "guest.archidiecezja.katowice.pl"
     country: "PL"
-  - 
+  -
     ip: "212.106.189.210"
     country: "PL"
     reverse: "ns.imn.gliwice.pl"
     provider: "SILWEB-AS-EDU Silesian University of Technology, Computer Centre"
-  - 
+  -
     ip: "213.227.80.200"
     provider: "SILWEB-AS-EDU Silesian University of Technology, Computer Centre"
     reverse: "dns.gig.eu"
     country: "PL"
-  - 
+  -
     ip: "85.218.125.11"
     country: "CH"
     reverse: "ns2.practeo.ch"
     provider: "SIMA-LAUSANNE-AS Service Multimedia"
-  - 
+  -
     ip: "85.234.140.65"
     provider: "SIMPLYTRANSIT Simply Transit Ltd"
     reverse: "dr65.navaho.co.uk.140.234.85.in-addr.arpa"
     country: "GB"
-  - 
+  -
     ip: "92.48.112.254"
     provider: "SIMPLYTRANSIT Simply Transit Ltd"
     reverse: "ns1.rcmf.co.uk"
     country: "GB"
-  - 
+  -
     ip: "89.107.158.146"
     provider: "SITEL-PL SITEL - Polish IP Transit Networks"
     reverse: "do-kgnet.sitel.net.pl"
     country: "PL"
-  - 
+  -
     ip: "217.10.134.2"
     provider: "SIXDG-AS Six Degrees Managed Data Limited"
     reverse: "ns0.air-band.net"
     country: "GB"
-  - 
+  -
     ip: "91.189.0.2"
     provider: "SKOMUR-AS _Skomur_ J. K. Pruscy, D. P. Kaczmarek"
     reverse: "szwagier.netburg.pl"
     country: "PL"
-  - 
+  -
     ip: "91.189.0.5"
     country: "PL"
     reverse: "ns2.skomur.pl"
     provider: "SKOMUR-AS _Skomur_ J. K. Pruscy, D. P. Kaczmarek"
-  - 
+  -
     ip: "195.46.39.39"
     country: "RU"
     reverse: "dns1.safedns.com"
     provider: "SKYDNS-AS SkyDNS, Ltd."
-  - 
+  -
     ip: "195.46.39.40"
     provider: "SKYDNS-AS SkyDNS, Ltd."
     reverse: "dns2.safedns.com"
     country: "RU"
-  - 
+  -
     ip: "88.204.14.1"
     country: "RU"
     reverse: "ns1.tomgate.net"
     provider: "SKYLINE-AS SkyLine Ltd"
-  - 
+  -
     ip: "193.109.53.2"
     country: "CH"
     reverse: "dns1.skypro.ch"
     provider: "SKYPRO-CH Skypro AG"
-  - 
+  -
     ip: "193.93.125.197"
     provider: "SKYROCK Telefun SAS"
     reverse: "ns5gslb.skyrock.net"
     country: "FR"
-  - 
+  -
     ip: "66.78.202.254"
     country: "US"
     reverse: "ns1.smartcity.com"
     provider: "SMARTCITY-LASVEGAS - Smart City Networks, L.P."
-  - 
+  -
     ip: "80.94.34.230"
     provider: "SMARTWAYS Smartways Autonomous System"
     reverse: "80.94.34.230"
     country: "GB"
-  - 
+  -
     ip: "212.3.133.6"
     provider: "SMOLENSK-AS OJSC Rostelecom"
     reverse: "ns.globus.smolensk.ru"
     country: "RU"
-  - 
+  -
     ip: "194.106.210.5"
     country: "PL"
     reverse: "dns.astral.lodz.pl"
     provider: "SMTVSAT-ASTRAL-AS STOWARZYSZENIE MILOSNIKOW TELEWIZJI SATELITARNEJ ASTRAL"
-  - 
+  -
     ip: "194.106.210.20"
     provider: "SMTVSAT-ASTRAL-AS STOWARZYSZENIE MILOSNIKOW TELEWIZJI SATELITARNEJ ASTRAL"
     reverse: "cable-cmr.astral.lodz.pl"
     country: "PL"
-  - 
+  -
     ip: "202.213.195.5"
     provider: "SO-NET So-net Entertainment Corporation"
     reverse: "ns10.sinfony.ad.jp"
     country: "JP"
-  - 
+  -
     ip: "202.238.95.24"
     country: "JP"
     reverse: "dnss1.so-net.ne.jp"
     provider: "SO-NET So-net Entertainment Corporation"
-  - 
+  -
     ip: "216.106.1.2"
     provider: "SOCKET - Socket Internet Services Corporation"
     reverse: "ns1.socket.net"
     country: "US"
-  - 
+  -
     ip: "193.46.213.2"
     provider: "SOESTA-AS _Soesta_ ZAO"
     reverse: "ns.vip-line.ru"
     country: "RU"
-  - 
+  -
     ip: "50.116.22.226"
     provider: "SOFTLAYER - SoftLayer Technologies Inc."
     reverse: "paranoia.virtual-dope.com"
     country: "US"
-  - 
+  -
     ip: "50.116.23.211"
     country: "US"
     reverse: "www.eqnic.net"
     provider: "SOFTLAYER - SoftLayer Technologies Inc."
-  - 
+  -
     ip: "50.116.28.138"
     provider: "SOFTLAYER - SoftLayer Technologies Inc."
     reverse: "li490-138.members.linode.com"
     country: "US"
-  - 
+  -
     ip: "69.164.196.21"
     provider: "SOFTLAYER - SoftLayer Technologies Inc."
     reverse: "ryujin.darkdna.net"
     country: "US"
-  - 
+  -
     ip: "72.14.183.109"
     provider: "SOFTLAYER - SoftLayer Technologies Inc."
     reverse: "whirlpool.whoneedszzz.pw"
     country: "US"
-  - 
+  -
     ip: "193.203.80.90"
     provider: "SOHONETEU-AS Sohonet Limited"
     reverse: "ns1.sohonet.co.uk"
     country: "GB"
-  - 
+  -
     ip: "193.203.82.66"
     country: "GB"
     reverse: "ns0.sohonet.co.uk"
     provider: "SOHONETEU-AS Sohonet Limited"
-  - 
+  -
     ip: "208.201.224.11"
     country: "US"
     reverse: "ns1.sonic.net"
     provider: "SONOMA - Sonoma Interconnect"
-  - 
+  -
     ip: "208.201.224.33"
     provider: "SONOMA - Sonoma Interconnect"
     reverse: "ns2.sonic.net"
     country: "US"
-  - 
+  -
     ip: "194.186.254.25"
     country: "RU"
     reverse: "194.186.254.25"
     provider: "SOVAM-AS OJSC _Vimpelcom_"
-  - 
+  -
     ip: "195.68.155.2"
     country: "RU"
     reverse: "mail1.petroal.ru"
     provider: "SOVAM-AS OJSC _Vimpelcom_"
-  - 
+  -
     ip: "213.33.241.254"
     country: "RU"
     reverse: "ns.olly.ru"
     provider: "SOVAM-AS OJSC _Vimpelcom_"
-  - 
+  -
     ip: "85.93.146.14"
     country: "RU"
     reverse: "mx.damahost.ru"
     provider: "SPACENET-AS JSC Internet-Cosmos"
-  - 
+  -
     ip: "85.93.150.2"
     provider: "SPACENET-AS JSC Internet-Cosmos"
     reverse: "mail.viphost.ru"
     country: "RU"
-  - 
+  -
     ip: "68.28.50.91"
     country: "US"
     reverse: "ns1.brbncar12.spcsdns.net"
     provider: "SPCS - Sprint Personal Communications Systems"
-  - 
+  -
     ip: "68.28.82.91"
     provider: "SPCS - Sprint Personal Communications Systems"
     reverse: "ns1.kscymar06.spcsdns.net"
     country: "US"
-  - 
+  -
     ip: "68.28.114.91"
     country: "US"
     reverse: "ns1.ekrgmar02.spcsdns.net"
     provider: "SPCS - Sprint Personal Communications Systems"
-  - 
+  -
     ip: "68.28.122.93"
     provider: "SPCS - Sprint Personal Communications Systems"
     reverse: "ns2.ekrgmar02.spcsdns.net"
     country: "US"
-  - 
+  -
     ip: "68.28.154.91"
     country: "US"
     reverse: "ns1.kscymbr11.spcsdns.net"
     provider: "SPCS - Sprint Personal Communications Systems"
-  - 
+  -
     ip: "68.28.154.92"
     provider: "SPCS - Sprint Personal Communications Systems"
     reverse: "ns2.chcgibr05.spcsdns.net"
     country: "US"
-  - 
+  -
     ip: "68.28.178.91"
     country: "US"
     reverse: "ns1.ftwotar04.spcsdns.net"
     provider: "SPCS - Sprint Personal Communications Systems"
-  - 
+  -
     ip: "68.28.186.91"
     provider: "SPCS - Sprint Personal Communications Systems"
     reverse: "ns2.ftwotar04.spcsdns.net"
     country: "US"
-  - 
+  -
     ip: "68.28.242.91"
     country: "US"
     reverse: "ns1.atlngar03.spcsdns.net"
     provider: "SPCS - Sprint Personal Communications Systems"
-  - 
+  -
     ip: "68.28.250.92"
     provider: "SPCS - Sprint Personal Communications Systems"
     reverse: "ns2.atlngar03.spcsdns.net"
     country: "US"
-  - 
+  -
     ip: "207.15.68.36"
     country: "US"
     reverse: "osscdns02.spcsdns.net"
     provider: "SPCS - Sprint Personal Communications Systems"
-  - 
+  -
     ip: "207.15.68.164"
     provider: "SPCS - Sprint Personal Communications Systems"
     reverse: "osscdns01.spcsdns.net"
     country: "US"
-  - 
+  -
     ip: "195.42.232.2"
     provider: "SPEEDBONE-AS Speedbone Internet & Connectivity GmbH"
     reverse: "ns3.mysnot.de"
     country: "DE"
-  - 
+  -
     ip: "80.79.179.2"
     country: "RU"
     reverse: "ns2.altegrosky.ru"
     provider: "SPIN CJSC Race Telecom"
-  - 
+  -
     ip: "217.21.96.1"
     country: "RU"
     reverse: "ns1.racetelecom.net"
     provider: "SPIN CJSC Race Telecom"
-  - 
+  -
     ip: "203.23.236.66"
     country: "AU"
     reverse: "comcen.comcen.com.au"
     provider: "SPIN-INTERNET-AP Spin Internet Service"
-  - 
+  -
     ip: "203.23.236.69"
     country: "AU"
     reverse: "angel.comcen.com.au"
     provider: "SPIN-INTERNET-AP Spin Internet Service"
-  - 
+  -
     ip: "206.207.94.145"
     provider: "SQN-NET - SpeedyQuick Networks Inc"
     reverse: "ns8.matraex.com"
     country: "US"
-  - 
+  -
     ip: "193.34.82.2"
     provider: "SSA-AS SSA Ltd"
     reverse: "ns2.unidatacentre.com"
     country: "IE"
-  - 
+  -
     ip: "83.243.39.59"
     country: "PL"
     reverse: "dns2.stansat.pl"
     provider: "STANSAT Stansat Stanislaw Grzesik"
-  - 
+  -
     ip: "83.243.39.61"
     provider: "STANSAT Stansat Stanislaw Grzesik"
     reverse: "dns1.stansat.pl"
     country: "PL"
-  - 
+  -
     ip: "84.16.129.129"
     country: "RU"
     reverse: "ns2.freeset.ru"
     provider: "STARTEL-AS JSC Startelecom-North"
-  - 
+  -
     ip: "81.222.84.2"
     provider: "STARTELECOMSPB-AS Startelecom Severo-Zapad JSC"
     reverse: "ns2.stnw.ru"
     country: "RU"
-  - 
+  -
     ip: "89.17.224.44"
     provider: "STARTV Media Operator Sp. z o. o."
     reverse: "dnsb.star.net.pl"
     country: "PL"
-  - 
+  -
     ip: "85.159.32.17"
     provider: "STAVCOM-AS _Stavropol_skie Kommunikacii_ OOO"
     reverse: "ns.stavcom.ru"
     country: "RU"
-  - 
+  -
     ip: "85.159.33.62"
     country: "RU"
     reverse: "ns2.stavcom.ru"
     provider: "STAVCOM-AS _Stavropol_skie Kommunikacii_ OOO"
-  - 
+  -
     ip: "195.2.192.252"
     country: "RU"
     reverse: "host195-2-192-252.stavnet.ru"
     provider: "STAVROPOL-COMPNET-AS Stavropol Computer Networks Ltd."
-  - 
+  -
     ip: "92.124.194.206"
     country: "RU"
     reverse: "ns3.stbur.ru"
     provider: "STBUR-AS OJSC Rostelecom"
-  - 
+  -
     ip: "85.172.0.250"
     provider: "STC-AS _Southern Telecommunications Company_ PJSC"
     reverse: "ns.kes.ru"
     country: "RU"
-  - 
+  -
     ip: "79.171.168.3"
     country: "RU"
     reverse: "ns.steleport.ru"
     provider: "STELEPORT-AS Sputnik TELEPORT"
-  - 
+  -
     ip: "91.205.208.49"
     country: "RU"
     reverse: "91.205.208.49"
     provider: "STELS-COMMUNICATIONS-AS Kommunikatsyi Stels Ltd."
-  - 
+  -
     ip: "85.214.100.186"
     country: "DE"
     reverse: "sunshine.resolution.de"
     provider: "STRATO STRATO AG"
-  - 
+  -
     ip: "85.214.132.203"
     provider: "STRATO STRATO AG"
     reverse: "ns2.fernholz-it.net"
     country: "DE"
-  - 
+  -
     ip: "77.93.124.252"
     provider: "STREAM-TV-TAMBOV-AS CJSC _COMSTAR-Regions_"
     reverse: "ns1.tambov.stream.ru"
     country: "RU"
-  - 
+  -
     ip: "217.75.0.66"
     country: "IE"
     reverse: "ns1.strencom.net"
     provider: "STRENCOM Fulnett Limited"
-  - 
+  -
     ip: "216.106.184.6"
     country: "US"
     reverse: "rs2.ststelecom.com"
     provider: "STS-TELECOM-AS-1 - STS TELECOM"
-  - 
+  -
     ip: "81.200.5.165"
     country: "RU"
     reverse: "81.200.5.165"
     provider: "SU29-AS ISP _Gorcom_"
-  - 
+  -
     ip: "208.180.42.68"
     provider: "SUDDENLINK-COMMUNICATIONS - Suddenlink Communications"
     reverse: "rdns01.suddenlink.net"
     country: "US"
-  - 
+  -
     ip: "208.180.42.100"
     country: "US"
     reverse: "rdns02.suddenlink.net"
     provider: "SUDDENLINK-COMMUNICATIONS - Suddenlink Communications"
-  - 
+  -
     ip: "208.180.83.133"
     provider: "SUDDENLINK-COMMUNICATIONS - Suddenlink Communications"
     reverse: "rdns-lbbk-a.suddenlink.net"
     country: "US"
-  - 
+  -
     ip: "217.24.48.30"
     country: "DE"
     reverse: "dns2.dacor.de"
     provider: "SUEC-DACOR-AS suec // dacor GmbH"
-  - 
+  -
     ip: "217.24.50.254"
     provider: "SUEC-DACOR-AS suec // dacor GmbH"
     reverse: "dns1.dacor.de"
     country: "DE"
-  - 
+  -
     ip: "193.33.142.4"
     country: "CH"
     reverse: "ns.xmc.ch"
     provider: "SUNRISE Sunrise Communications AG"
-  - 
+  -
     ip: "212.54.160.7"
     provider: "SURELINE-COMMUNICATIONS-UK Sureline Communications Limited"
     reverse: "ns0.sureline.net"
     country: "GB"
-  - 
+  -
     ip: "85.88.19.10"
     country: "DE"
     reverse: "ns.x-ns.de"
     provider: "SURFPLANET-AS Surfplanet GmbH"
-  - 
+  -
     ip: "85.88.19.11"
     provider: "SURFPLANET-AS Surfplanet GmbH"
     reverse: "ns3.x-ns.de"
     country: "DE"
-  - 
+  -
     ip: "217.117.111.1"
     provider: "SURFPLANET-AS Surfplanet GmbH"
     reverse: "ns1.uniserve.de"
     country: "DE"
-  - 
+  -
     ip: "194.169.247.211"
     country: "RU"
     reverse: "ns.admsurgut.ru"
     provider: "SURGUTTEL-AS Net By Net Holding LLC"
-  - 
+  -
     ip: "62.165.32.250"
     country: "RU"
     reverse: "ns.suttk.ru"
     provider: "SUTTK-AS Southern Urals TransTelecom Regional Office of TransTelecom Largest fiber-optic carrier ISP/ASP Chelyabinsk, Russia"
-  - 
+  -
     ip: "62.165.33.250"
     provider: "SUTTK-AS Southern Urals TransTelecom Regional Office of TransTelecom Largest fiber-optic carrier ISP/ASP Chelyabinsk, Russia"
     reverse: "ns1.suttk.ru"
     country: "RU"
-  - 
+  -
     ip: "89.237.7.132"
     country: "RU"
     reverse: "89-237-7-132.suttk.ru"
     provider: "SUTTK-AS Southern Urals TransTelecom Regional Office of TransTelecom Largest fiber-optic carrier ISP/ASP Chelyabinsk, Russia"
-  - 
+  -
     ip: "213.152.128.10"
     country: "RU"
     reverse: "ns.linxtelecom.ru"
     provider: "SVYAZVSD LLC Svyaz VSD"
-  - 
+  -
     ip: "213.152.130.1"
     provider: "SVYAZVSD LLC Svyaz VSD"
     reverse: "ns2.ionip.ru"
     country: "RU"
-  - 
+  -
     ip: "213.152.142.12"
     country: "RU"
     reverse: "rti.21th.com"
     provider: "SVYAZVSD LLC Svyaz VSD"
-  - 
+  -
     ip: "158.255.213.244"
     country: "GB"
     reverse: "chicago.godau.eu"
     provider: "SWIFTWAY-AS Swiftway Sp. z o.o."
-  - 
+  -
     ip: "193.239.21.20"
     country: "CH"
     reverse: "ns1.mrmouse.ch"
     provider: "SWISSCOM Swisscom (Switzerland) Ltd"
-  - 
+  -
     ip: "193.239.21.21"
     provider: "SWISSCOM Swisscom (Switzerland) Ltd"
     reverse: "ns2.mrmouse.ch"
     country: "CH"
-  - 
+  -
     ip: "194.147.53.3"
     provider: "SWISSCOM Swisscom (Switzerland) Ltd"
     reverse: "ns2.baumergroup.com"
     country: "CH"
-  - 
+  -
     ip: "195.186.1.110"
     provider: "SWISSCOM Swisscom (Switzerland) Ltd"
     reverse: "dns1.bluewin.ch"
     country: "CH"
-  - 
+  -
     ip: "195.186.1.111"
     country: "CH"
     reverse: "dns2.bluewin.ch"
     provider: "SWISSCOM Swisscom (Switzerland) Ltd"
-  - 
+  -
     ip: "195.186.4.110"
     provider: "SWISSCOM Swisscom (Switzerland) Ltd"
     reverse: "dns3.bluewin.ch"
     country: "CH"
-  - 
+  -
     ip: "195.186.4.111"
     country: "CH"
     reverse: "dns4.bluewin.ch"
     provider: "SWISSCOM Swisscom (Switzerland) Ltd"
-  - 
+  -
     ip: "213.200.247.180"
     provider: "SWISSCOM Swisscom (Switzerland) Ltd"
     reverse: "ns2.frey-net.ch"
     country: "CH"
-  - 
+  -
     ip: "194.31.241.5"
     provider: "SYCOR SYCOR GmbH"
     reverse: "dns1.sycor-world.de"
     country: "DE"
-  - 
+  -
     ip: "83.229.241.146"
     provider: "SYNTERRA-AS CJSC Synterra"
     reverse: "ns3.main.synterra.ru"
     country: "RU"
-  - 
+  -
     ip: "195.230.64.13"
     country: "RU"
     reverse: "ns.main.synterra.ru"
     provider: "SYNTERRA-AS CJSC Synterra"
-  - 
+  -
     ip: "209.251.33.2"
     provider: "SYSSRC - System Source"
     reverse: "dns.syssrc.com"
     country: "US"
-  - 
+  -
     ip: "194.140.95.33"
     country: "ES"
     reverse: "domo.soluziona.com"
     provider: "Soluziona Consultoria y Tecnologia"
-  - 
+  -
     ip: "212.192.35.4"
     provider: "State Educational Institution of Higher Professional Education Omsk State University of F.M.Dostoevsky"
     reverse: "doors.univer.omsk.su"
     country: "RU"
-  - 
+  -
     ip: "66.181.32.10"
     country: "US"
     reverse: "ns1.ip.us.tachyon.net"
     provider: "TACHYON-INC - Tachyon Networks, Inc."
-  - 
+  -
     ip: "66.181.32.11"
     provider: "TACHYON-INC - Tachyon Networks, Inc."
     reverse: "ns2.ip.us.tachyon.net"
     country: "US"
-  - 
+  -
     ip: "217.114.16.1"
     country: "RU"
     reverse: "ns.tagiltelecom.ru"
     provider: "TAGILTELECOM-AS JSC _TagilTelecom_"
-  - 
+  -
     ip: "85.236.161.1"
     provider: "TAHIONISP-AS LLC SIP _NIS_"
     reverse: "mail.samaralan.ru"
     country: "RU"
-  - 
+  -
     ip: "213.240.150.2"
     provider: "TAL-DE TAL.DE Klaus Internet Service GmbH"
     reverse: "mail.berg.net"
     country: "DE"
-  - 
+  -
     ip: "80.74.251.37"
     country: "GB"
     reverse: "kursk.odysseydsl.co.uk"
     provider: "TALKINTERNET Talk Internet"
-  - 
+  -
     ip: "195.245.94.2"
     provider: "TAMI-AS P.H.U. TAMI - Wojciech Sterna"
     reverse: "alfa2.tami.pl"
     country: "PL"
-  - 
+  -
     ip: "212.53.34.1"
     country: "RU"
     reverse: "dns.tario.ru"
     provider: "TARIO Tario Communications CJSC"
-  - 
+  -
     ip: "217.117.128.3"
     country: "PL"
     reverse: "info.tarman.pl"
     provider: "TARMAN Tarnowski Osrodek Informacyjny Aleksander Rajski"
-  - 
+  -
     ip: "217.117.128.4"
     provider: "TARMAN Tarnowski Osrodek Informacyjny Aleksander Rajski"
     reverse: "mefisto.toi.tarman.pl"
     country: "PL"
-  - 
+  -
     ip: "217.26.0.2"
     country: "RU"
     reverse: "ns.tascom.ru"
     provider: "TASCOM ZAO Tascom"
-  - 
+  -
     ip: "217.26.1.2"
     provider: "TASCOM ZAO Tascom"
     reverse: "ns2.tascom.ru"
     country: "RU"
-  - 
+  -
     ip: "153.19.0.50"
     provider: "TASK-AS Technical University of Gdansk, Academic Computer Center TASK"
     reverse: "dns2.task.gda.pl"
     country: "PL"
-  - 
+  -
     ip: "153.19.1.254"
     country: "PL"
     reverse: "rabarbar.ug.edu.pl"
     provider: "TASK-AS Technical University of Gdansk, Academic Computer Center TASK"
-  - 
+  -
     ip: "153.19.250.100"
     provider: "TASK-AS Technical University of Gdansk, Academic Computer Center TASK"
     reverse: "dns.task.gda.pl"
     country: "PL"
-  - 
+  -
     ip: "85.233.82.86"
     country: "RU"
     reverse: "ns.tatais.ru"
     provider: "TATAISNEFT-AS LLC TatAISneft"
-  - 
+  -
     ip: "93.91.22.127"
     country: "GB"
     reverse: "ns-dr-b.thomasmurray.com"
     provider: "TBSH The Bunker Secure Hosting Limited"
-  - 
+  -
     ip: "140.186.1.14"
     country: "US"
     reverse: "ns2.cent.net"
     provider: "TCIX - Meganet Communications"
-  - 
+  -
     ip: "204.107.252.7"
     country: "US"
     reverse: "ns2.cape.com"
     provider: "TCIX - Meganet Communications"
-  - 
+  -
     ip: "209.213.72.9"
     country: "US"
     reverse: "ns1.bos.ma.meganet.net"
     provider: "TCIX - Meganet Communications"
-  - 
+  -
     ip: "62.243.190.7"
     provider: "TDC TDC Data Networks"
     reverse: "ns1.avalonia.com"
     country: "DK"
-  - 
+  -
     ip: "62.243.190.8"
     country: "DK"
     reverse: "ns2.avalonia.com"
     provider: "TDC TDC Data Networks"
-  - 
+  -
     ip: "62.243.190.9"
     provider: "TDC TDC Data Networks"
     reverse: "ns4.avalonia.com"
     country: "DK"
-  - 
+  -
     ip: "80.199.84.238"
     provider: "TDC TDC Data Networks"
     reverse: "ns3.avalonia.com"
     country: "DK"
-  - 
+  -
     ip: "87.54.44.10"
     provider: "TDC TDC Data Networks"
     reverse: "cpe.ge-0-2-0-683.hknqu1.dk.customer.tdc.net"
     country: "DK"
-  - 
+  -
     ip: "193.89.221.2"
     country: "DK"
     reverse: "ns.bang-olufsen.dk"
     provider: "TDC TDC Data Networks"
-  - 
+  -
     ip: "193.89.221.124"
     provider: "TDC TDC Data Networks"
     reverse: "ns2.bang-olufsen.dk"
     country: "DK"
-  - 
+  -
     ip: "193.89.248.1"
     country: "DK"
     reverse: "ns.christiania.org"
     provider: "TDC TDC Data Networks"
-  - 
+  -
     ip: "194.239.1.21"
     provider: "TDC TDC Data Networks"
     reverse: "ns.2m.dk"
     country: "DK"
-  - 
+  -
     ip: "194.239.75.225"
     country: "DK"
     reverse: "194.239.75.225"
     provider: "TDC TDC Data Networks"
-  - 
+  -
     ip: "194.239.164.25"
     provider: "TDC TDC Data Networks"
     reverse: "ns.molgaard.dk"
     country: "DK"
-  - 
+  -
     ip: "195.137.236.100"
     provider: "TDC TDC Data Networks"
     reverse: "195.137.236.100"
     country: "DK"
-  - 
+  -
     ip: "212.130.1.68"
     provider: "TDC TDC Data Networks"
     reverse: "ns2.mikrograf.dk"
     country: "DK"
-  - 
+  -
     ip: "212.130.242.154"
     country: "DK"
     reverse: "212.130.242.154"
     provider: "TDC TDC Data Networks"
-  - 
+  -
     ip: "91.197.164.11"
     country: "FR"
     reverse: "fw-1.tdf-pmm.net"
     provider: "TDFPMM SMARTJOG SAS"
-  - 
+  -
     ip: "91.197.165.11"
     provider: "TDFPMM SMARTJOG SAS"
     reverse: "fw-2.tdf-pmm.net"
     country: "FR"
-  - 
+  -
     ip: "216.165.129.158"
     provider: "TDS-AS - TDS TELECOM"
     reverse: "ns7.dns.tds.net"
     country: "US"
-  - 
+  -
     ip: "216.170.153.146"
     provider: "TDS-AS - TDS TELECOM"
     reverse: "ns8.dns.tds.net"
     country: "US"
-  - 
+  -
     ip: "92.42.200.66"
     provider: "TE-AS JSC _Tyumenenergo_"
     reverse: "ns.te.ru"
     country: "RU"
-  - 
+  -
     ip: "91.212.64.254"
     provider: "TECCO-AS Tecco Company Ltd"
     reverse: "mail.tecco.ru"
     country: "RU"
-  - 
+  -
     ip: "66.199.31.131"
     country: "US"
     reverse: "ns3.teklinks.com"
     provider: "TEKLINKS - TekLinks, Inc."
-  - 
+  -
     ip: "89.107.16.2"
     provider: "TELECITY-LON TELECITYGROUP INTERNATIONAL LIMITED"
     reverse: "ns0.ukgrid.net"
     country: "GB"
-  - 
+  -
     ip: "95.215.149.5"
     provider: "TELECOMSERVICE-AS PS TelecomService Ltd."
     reverse: "ns1.telecomnet.ru"
     country: "RU"
-  - 
+  -
     ip: "95.215.150.15"
     country: "RU"
     reverse: "ns2.cnrg.ru"
     provider: "TELECOMSERVICE-AS PS TelecomService Ltd."
-  - 
+  -
     ip: "89.185.75.243"
     country: "RU"
     reverse: "ns1.nm-s.ru"
     provider: "TELECOM_MANAGEMENT Telecom Management Company Limited"
-  - 
+  -
     ip: "89.185.75.244"
     provider: "TELECOM_MANAGEMENT Telecom Management Company Limited"
     reverse: "ns2.nm-s.ru"
     country: "RU"
-  - 
+  -
     ip: "62.177.42.174"
     country: "RU"
     reverse: "ns.permtelecon.ru"
     provider: "TELECON-AS LTD Telecon"
-  - 
+  -
     ip: "80.84.64.25"
     country: "GB"
     reverse: "ns2.uklinux.net"
     provider: "TELEDATA Teledata UK Limited"
-  - 
+  -
     ip: "193.148.159.170"
     country: "ES"
     reverse: "ns1.correos.es"
     provider: "TELEFONICA-DATA-ESPANA TELEFONICA DE ESPANA"
-  - 
+  -
     ip: "194.179.1.101"
     country: "ES"
     reverse: "101.red-194-179-1.static.ccgg.telefonica.net"
     provider: "TELEFONICA-DATA-ESPANA TELEFONICA DE ESPANA"
-  - 
+  -
     ip: "194.179.109.10"
     provider: "TELEFONICA-DATA-ESPANA TELEFONICA DE ESPANA"
     reverse: "dns.caixacatalunya.es"
     country: "ES"
-  - 
+  -
     ip: "195.77.116.2"
     provider: "TELEFONICA-DATA-ESPANA TELEFONICA DE ESPANA"
     reverse: "pascal.entorno.es"
     country: "ES"
-  - 
+  -
     ip: "195.77.116.7"
     country: "ES"
     reverse: "ns2.entornodns.com"
     provider: "TELEFONICA-DATA-ESPANA TELEFONICA DE ESPANA"
-  - 
+  -
     ip: "195.77.234.6"
     provider: "TELEFONICA-DATA-ESPANA TELEFONICA DE ESPANA"
     reverse: "dns1.cirsa.com"
     country: "ES"
-  - 
+  -
     ip: "213.0.77.5"
     country: "ES"
     reverse: "netra1.infotelecom.es"
     provider: "TELEFONICA-DATA-ESPANA TELEFONICA DE ESPANA"
-  - 
+  -
     ip: "85.90.33.5"
     country: "GB"
     reverse: "ukns4.telehouse.net"
     provider: "TELEHOUSE Telehouse Inter. Corp. of Europe Ltd As Number"
-  - 
+  -
     ip: "85.90.34.5"
     provider: "TELEHOUSE Telehouse Inter. Corp. of Europe Ltd As Number"
     reverse: "ukns5.telehouse.net"
     country: "GB"
-  - 
+  -
     ip: "85.90.35.5"
     country: "GB"
     reverse: "frns1.telehouse.net"
     provider: "TELEHOUSE Telehouse Inter. Corp. of Europe Ltd As Number"
-  - 
+  -
     ip: "85.90.48.10"
     provider: "TELEHOUSE Telehouse Inter. Corp. of Europe Ltd As Number"
     reverse: "ns2.fr.kddi.com"
     country: "GB"
-  - 
+  -
     ip: "109.73.52.11"
     provider: "TELEMAXX TelemaxX Telekommunikation GmbH"
     reverse: "ns1.topdns.ch"
     country: "DE"
-  - 
+  -
     ip: "109.73.52.12"
     country: "DE"
     reverse: "ns2.topdns.ch"
     provider: "TELEMAXX TelemaxX Telekommunikation GmbH"
-  - 
+  -
     ip: "213.144.3.210"
     country: "DE"
     reverse: "dns.pfalzkom.de"
     provider: "TELEMAXX TelemaxX Telekommunikation GmbH"
-  - 
+  -
     ip: "81.200.81.10"
     provider: "TELEMEDNET TELEMEDNET - net of Center Children Telemedicin in Moscow"
     reverse: "ftpserver.cdt.ru"
     country: "RU"
-  - 
+  -
     ip: "81.200.85.137"
     country: "RU"
     reverse: "mail.vcmk.ru"
     provider: "TELEMEDNET TELEMEDNET - net of Center Children Telemedicin in Moscow"
-  - 
+  -
     ip: "81.22.204.35"
     provider: "TELESET-KAZAN Teleset CJSC"
     reverse: "zero.hq.telecet.com"
     country: "RU"
-  - 
+  -
     ip: "80.239.175.131"
     provider: "TELIANET TeliaSonera International Carrier"
     reverse: "os22.deltastar-online.de"
     country: "EU"
-  - 
+  -
     ip: "80.239.175.200"
     country: "EU"
     reverse: "ns2.adnsch.com"
     provider: "TELIANET TeliaSonera International Carrier"
-  - 
+  -
     ip: "80.239.175.201"
     provider: "TELIANET TeliaSonera International Carrier"
     reverse: "80.239.175.201"
     country: "EU"
-  - 
+  -
     ip: "80.239.175.202"
     country: "EU"
     reverse: "80.239.175.202"
     provider: "TELIANET TeliaSonera International Carrier"
-  - 
+  -
     ip: "80.239.175.220"
     provider: "TELIANET TeliaSonera International Carrier"
     reverse: "80.239.175.220"
     country: "EU"
-  - 
+  -
     ip: "80.239.207.176"
     country: "EU"
     reverse: "ns1.pokoeln.de"
     provider: "TELIANET TeliaSonera International Carrier"
-  - 
+  -
     ip: "80.239.207.200"
     provider: "TELIANET TeliaSonera International Carrier"
     reverse: "ns1.adnsch.com"
     country: "EU"
-  - 
+  -
     ip: "62.44.158.10"
     country: "SE"
     reverse: "ns.teliamobile.dk"
     provider: "TELIANET-DENMARK TeliaSonera AB"
-  - 
+  -
     ip: "62.44.158.11"
     provider: "TELIANET-DENMARK TeliaSonera AB"
     reverse: "ns1.teliamobile.dk"
     country: "SE"
-  - 
+  -
     ip: "195.110.17.40"
     country: "SE"
     reverse: "ns2.dk.logica.com"
     provider: "TELIANET-DENMARK TeliaSonera AB"
-  - 
+  -
     ip: "216.144.192.252"
     country: "US"
     reverse: "ns2.digitalrealm.net"
     provider: "TELNET - Telnet Worldwide, Inc."
-  - 
+  -
     ip: "154.32.105.18"
     provider: "TELSTRAEUROPELTD-BACKBONE Telstra Europe Ltd"
     reverse: "res1.dns.uk.psi.net"
     country: "EU"
-  - 
+  -
     ip: "154.32.107.18"
     country: "EU"
     reverse: "res2.dns.uk.psi.net"
     provider: "TELSTRAEUROPELTD-BACKBONE Telstra Europe Ltd"
-  - 
+  -
     ip: "154.32.109.18"
     provider: "TELSTRAEUROPELTD-BACKBONE Telstra Europe Ltd"
     reverse: "res3.dns.uk.psi.net"
     country: "EU"
-  - 
+  -
     ip: "216.198.139.68"
     country: "CA"
     reverse: "ns1.clearnet.com"
     provider: "TELUS-3 - TELUS MOBILITY"
-  - 
+  -
     ip: "216.198.139.69"
     provider: "TELUS-3 - TELUS MOBILITY"
     reverse: "ns2.clearnet.com"
     country: "CA"
-  - 
+  -
     ip: "67.214.64.27"
     provider: "TELWEST-NETWORK-SVCS-STATIC - TEL WEST COMMUNICATIONS LLC"
     reverse: "dns1.telwestonline.com"
     country: "US"
-  - 
+  -
     ip: "195.47.208.15"
     provider: "TEXNOPOLIS Technopolis SA"
     reverse: "ns2.techlink.gr"
     country: "GR"
-  - 
+  -
     ip: "194.45.26.13"
     provider: "TGC-AS true global communications GmbH"
     reverse: "dimeola.ganesha.com"
     country: "DE"
-  - 
+  -
     ip: "194.45.26.20"
     country: "DE"
     reverse: "powell.ganesha.com"
     provider: "TGC-AS true global communications GmbH"
-  - 
+  -
     ip: "194.45.26.56"
     provider: "TGC-AS true global communications GmbH"
     reverse: "bechet.ganesha.com"
     country: "DE"
-  - 
+  -
     ip: "203.131.222.11"
     country: "TH"
     reverse: "ns.tu.ac.th"
     provider: "THAMMASAT-BORDER-AS Thammasat University in thailand"
-  - 
+  -
     ip: "93.95.226.146"
     provider: "THE-1984-AS 1984 ehf AS number"
     reverse: "teamhugs.is"
     country: "IS"
-  - 
+  -
     ip: "64.8.96.2"
     country: "US"
     reverse: "ns3.net1.net"
     provider: "THE-ALDRIDGE-NETWORK - The Aldridge Company"
-  - 
+  -
     ip: "207.44.226.173"
     provider: "THEPLANET-AS - ThePlanet.com Internet Services, Inc."
     reverse: "ns2.listau.com"
     country: "US"
-  - 
+  -
     ip: "216.116.96.2"
     country: "US"
     reverse: "nscl-01.tierzero.net"
     provider: "TIERZERO-AS11509 - Tierzero"
-  - 
+  -
     ip: "216.116.96.3"
     provider: "TIERZERO-AS11509 - Tierzero"
     reverse: "nscl-02.tierzero.net"
     country: "US"
-  - 
-    ip: "208.94.148.2"
-    provider: "TIGGEE - Tiggee LLC"
-    reverse: "ns0.dnsmadeeasy.com"
-    country: "US"
-  - 
+  -
     ip: "213.131.178.10"
     provider: "TIMICO Timico Ltd Autonomous System"
     reverse: "ns.flowsol.co.uk"
     country: "GB"
-  - 
+  -
     ip: "85.14.72.10"
     provider: "TKPSA-AS TKP S.A. is 3S.pl network operator."
     reverse: "85-14-72-10.static.akk.net.pl"
     country: "PL"
-  - 
+  -
     ip: "89.25.255.25"
     country: "PL"
     reverse: "ceres.bsi.bytom.pl"
     provider: "TKPSA-AS TKP S.A. is 3S.pl network operator."
-  - 
+  -
     ip: "91.192.56.2"
     provider: "TKPSA-AS TKP S.A. is 3S.pl network operator."
     reverse: "dns.omi4.net"
     country: "PL"
-  - 
+  -
     ip: "213.199.195.5"
     provider: "TKTELEKOM-AS TK Telekom sp. z o.o."
     reverse: "dns.nsn.pl"
     country: "PL"
-  - 
+  -
     ip: "213.199.195.20"
     country: "PL"
     reverse: "host.nsn.pl"
     provider: "TKTELEKOM-AS TK Telekom sp. z o.o."
-  - 
+  -
     ip: "46.182.18.228"
     country: "DE"
     reverse: "228-18-182-46.nbiserv.com"
     provider: "TNETKOM-AS Thueringer Netkom GmbH"
-  - 
+  -
     ip: "213.178.64.2"
     country: "DE"
     reverse: "ns.ki.tng.de"
     provider: "TNG-AS ennit server GmbH"
-  - 
+  -
     ip: "213.178.66.111"
     provider: "TNG-AS ennit server GmbH"
     reverse: "dns1.tng.de"
     country: "DE"
-  - 
+  -
     ip: "213.178.66.112"
     country: "DE"
     reverse: "dns2.tng.de"
     provider: "TNG-AS ennit server GmbH"
-  - 
+  -
     ip: "81.23.145.254"
     country: "RU"
     reverse: "relay.tnpko.ru"
     provider: "TNPKO-AS TNPKO JSC"
-  - 
+  -
     ip: "85.116.64.1"
     provider: "TOLVUN-AS Tolvun Autonomous system"
     reverse: "ns1.eyjar.is"
     country: "IS"
-  - 
+  -
     ip: "85.116.64.2"
     country: "IS"
     reverse: "ns2.eyjar.is"
     provider: "TOLVUN-AS Tolvun Autonomous system"
-  - 
+  -
     ip: "85.116.64.3"
     provider: "TOLVUN-AS Tolvun Autonomous system"
     reverse: "ns3.eyjar.is"
     country: "IS"
-  - 
+  -
     ip: "158.75.1.5"
     country: "PL"
     reverse: "blackbox.uci.umk.pl"
     provider: "TORMAN Torun Regional Computer Network"
-  - 
+  -
     ip: "194.88.158.2"
     provider: "TORON-AS Tadeusz Rzepecki TORON Przedsiebiorstwo Badawczo-Wdrozeniow"
     reverse: "hepa.toron.pl"
     country: "PL"
-  - 
+  -
     ip: "203.12.160.35"
     country: "AU"
     reverse: "dns1.tpgi.com.au"
     provider: "TPG-INTERNET-AP TPG Telecom Limited"
-  - 
+  -
     ip: "203.12.160.36"
     country: "AU"
     reverse: "dns2.tpgi.com.au"
     provider: "TPG-INTERNET-AP TPG Telecom Limited"
-  - 
+  -
     ip: "203.12.160.37"
     provider: "TPG-INTERNET-AP TPG Telecom Limited"
     reverse: "dns3.tpgi.com.au"
     country: "AU"
-  - 
+  -
     ip: "46.170.189.213"
     provider: "TPNET Telekomunikacja Polska S.A."
     reverse: "oxh213.internetdsl.tpnet.pl"
     country: "PL"
-  - 
+  -
     ip: "195.116.55.69"
     provider: "TPNET Telekomunikacja Polska S.A."
     reverse: "ns2.internetia.pl"
     country: "PL"
-  - 
+  -
     ip: "212.244.142.10"
     country: "PL"
     reverse: "212.244.142.10"
     provider: "TPNET Telekomunikacja Polska S.A."
-  - 
+  -
     ip: "213.25.159.2"
     country: "PL"
     reverse: "nsne.wist.com.pl"
     provider: "TPNET Telekomunikacja Polska S.A."
-  - 
+  -
     ip: "193.151.112.10"
     provider: "TPNETS TP Nets.com Tomasz Bathelt, Piotr Marciniak"
     reverse: "ns1.tpnets.com"
     country: "PL"
-  - 
+  -
     ip: "193.151.112.20"
     country: "PL"
     reverse: "ns2.tpnets.com"
     provider: "TPNETS TP Nets.com Tomasz Bathelt, Piotr Marciniak"
-  - 
+  -
     ip: "195.66.89.21"
     country: "CZ"
     reverse: "mail.tptus.ru"
     provider: "TPTUS-AS Eniseyneftegas Territorial Industrial Technical Management of Communication, CJSC"
-  - 
+  -
     ip: "93.188.188.11"
     provider: "TRANCOM-1 Trancom ISP"
     reverse: "ns0.trancom.ru"
     country: "RU"
-  - 
+  -
     ip: "93.188.188.18"
     country: "RU"
     reverse: "ns0.trancom.ru"
     provider: "TRANCOM-1 Trancom ISP"
-  - 
+  -
     ip: "93.188.191.106"
     provider: "TRANCOM-1 Trancom ISP"
     reverse: "ns1.trancom.ru"
     country: "RU"
-  - 
+  -
     ip: "193.110.43.67"
     provider: "TRANSFAIRNET Transfair-net GmbH"
     reverse: "ns2.intersolute.de"
     country: "DE"
-  - 
+  -
     ip: "193.56.127.9"
     provider: "TRANSIT-VPN-AS Orange S.A."
     reverse: "fr10.cat.fr"
     country: "FR"
-  - 
+  -
     ip: "212.28.34.90"
     country: "DE"
     reverse: "ns2.transkom.net"
     provider: "TRANSKOM Transkom Kommunikationsnetzwerke GmbH"
-  - 
+  -
     ip: "62.192.160.39"
     country: "RU"
     reverse: "mail2.trs.su"
     provider: "TRANSRS-AS TransRadioService"
-  - 
+  -
     ip: "62.33.38.3"
     country: "RU"
     reverse: "ns.dartel.ru"
     provider: "TRANSTELECOM TransTelecom"
-  - 
+  -
     ip: "62.33.39.3"
     provider: "TRANSTELECOM TransTelecom"
     reverse: "crusader.dartel.ru"
     country: "RU"
-  - 
+  -
     ip: "62.33.47.253"
     country: "RU"
     reverse: "ns2.mobukom.ru"
     provider: "TRANSTELECOM TransTelecom"
-  - 
+  -
     ip: "62.33.175.222"
     provider: "TRANSTELECOM TransTelecom"
     reverse: "etc-svyaz-gw.drogovozov.ru"
     country: "RU"
-  - 
+  -
     ip: "62.33.183.254"
     country: "RU"
     reverse: "ns4.astrakhan.ru"
     provider: "TRANSTELECOM TransTelecom"
-  - 
+  -
     ip: "80.82.168.3"
     provider: "TRANSTELECOM TransTelecom"
     reverse: "ns.lutek.ru"
     country: "RU"
-  - 
+  -
     ip: "80.237.26.202"
     country: "RU"
     reverse: "80.237.26.202"
     provider: "TRANSTELECOM TransTelecom"
-  - 
+  -
     ip: "80.237.44.179"
     provider: "TRANSTELECOM TransTelecom"
     reverse: "pub.belmail.ru"
     country: "RU"
-  - 
+  -
     ip: "80.237.54.26"
     country: "RU"
     reverse: "ms2.chte.ru"
     provider: "TRANSTELECOM TransTelecom"
-  - 
+  -
     ip: "80.237.54.27"
     provider: "TRANSTELECOM TransTelecom"
     reverse: "ms1.chte.ru"
     country: "RU"
-  - 
+  -
     ip: "80.237.85.4"
     country: "RU"
     reverse: "tiger.pfts.ru"
     provider: "TRANSTELECOM TransTelecom"
-  - 
+  -
     ip: "80.237.112.10"
     provider: "TRANSTELECOM TransTelecom"
     reverse: "ns1.kna.ru"
     country: "RU"
-  - 
+  -
     ip: "83.234.141.8"
     country: "RU"
     reverse: "kts.krasnokamensk.ru"
     provider: "TRANSTELECOM TransTelecom"
-  - 
+  -
     ip: "83.234.195.30"
     provider: "TRANSTELECOM TransTelecom"
     reverse: "ns2.st-ug.ru"
     country: "RU"
-  - 
+  -
     ip: "83.234.220.253"
     country: "RU"
     reverse: "ns1.l-net.ru"
     provider: "TRANSTELECOM TransTelecom"
-  - 
+  -
     ip: "217.150.32.18"
     country: "RU"
     reverse: "dns-prim.transtk.ru"
     provider: "TRANSTELECOM TransTelecom"
-  - 
+  -
     ip: "217.150.32.19"
     provider: "TRANSTELECOM TransTelecom"
     reverse: "dns-sec.transtk.ru"
     country: "RU"
-  - 
+  -
     ip: "217.150.35.129"
     country: "RU"
     reverse: "ns1.transtelecom.net"
     provider: "TRANSTELECOM TransTelecom"
-  - 
+  -
     ip: "217.150.45.17"
     provider: "TRANSTELECOM TransTelecom"
     reverse: "stroitelecom-gw.transtelecom.net"
     country: "RU"
-  - 
+  -
     ip: "217.150.51.150"
     country: "RU"
     reverse: "ns.tynda.ru"
     provider: "TRANSTELECOM TransTelecom"
-  - 
+  -
     ip: "208.70.22.22"
     provider: "TRIAD-TELECOM - Triad Telecom, Inc."
     reverse: "dns1.triadtelecom.com"
     country: "US"
-  - 
+  -
     ip: "203.144.207.29"
     provider: "TRUEINTERNET-AS-AP TRUE INTERNET Co.,Ltd."
     reverse: "dns1.asianet.co.th"
     country: "TH"
-  - 
+  -
     ip: "84.237.1.97"
     country: "RU"
     reverse: "mail.ispms.tsc.ru"
     provider: "TSC-AS High Current Electronics Institute"
-  - 
+  -
     ip: "78.41.24.2"
     provider: "TTCOMM TTcomm S.A."
     reverse: "ns2.ttcomm.net"
     country: "PL"
-  - 
+  -
     ip: "212.41.32.66"
     country: "RU"
     reverse: "dns.trtk.ru"
     provider: "TTK-AS OJSC Kompanya Troitsk Telecom"
-  - 
+  -
     ip: "78.31.96.2"
     country: "RU"
     reverse: "ns1.tverline.ru"
     provider: "TVERLINE-AS TverLine Ltd."
-  - 
+  -
     ip: "78.31.96.3"
     provider: "TVERLINE-AS TverLine Ltd."
     reverse: "ns2.tverline.ru"
     country: "RU"
-  - 
+  -
     ip: "195.140.236.250"
     country: "PL"
     reverse: "ns1.trzebnica.net"
     provider: "TVK-WROC-AS TVK Tel-Ka Wroclaw"
-  - 
+  -
     ip: "64.132.94.250"
     provider: "TWTC - tw telecom holdings, inc."
     reverse: "ns2.twtelecom.net"
     country: "US"
-  - 
+  -
     ip: "168.215.165.186"
     country: "US"
     reverse: "ns1.snan.twtelecom.net"
     provider: "TWTC - tw telecom holdings, inc."
-  - 
+  -
     ip: "168.215.210.50"
     provider: "TWTC - tw telecom holdings, inc."
     reverse: "ns1.orng.twtelecom.net"
     country: "US"
-  - 
+  -
     ip: "199.79.203.10"
     provider: "TWTC - tw telecom holdings, inc."
     reverse: "ns1.newtek.com"
     country: "US"
-  - 
+  -
     ip: "195.66.68.2"
     provider: "TZMO-AS Torunskie Zaklady Materialow Opatrunkowych S.A."
     reverse: "tzmo-sa.tzmo.com.pl"
     country: "PL"
-  - 
+  -
     ip: "207.248.32.2"
     country: "MX"
     reverse: "ns.intercable.net"
     provider: "Television Internacional, S.A. de C.V."
-  - 
+  -
     ip: "129.128.5.233"
     provider: "U-ALBERTA - University of Alberta"
     reverse: "name.ualberta.ca"
     country: "CA"
-  - 
+  -
     ip: "129.128.76.233"
     country: "CA"
     reverse: "nom.ualberta.ca"
     provider: "U-ALBERTA - University of Alberta"
-  - 
+  -
     ip: "128.135.249.50"
     country: "US"
     reverse: "dns2.uchicago.edu"
     provider: "U-CHICAGO-AS - University of Chicago"
-  - 
+  -
     ip: "137.82.1.1"
     country: "CA"
     reverse: "hub.ubc.ca"
     provider: "UBC - University of British Columbia"
-  - 
+  -
     ip: "61.122.116.147"
     provider: "UCOM UCOM Corp."
     reverse: "bb-ns01.fttx.co.jp"
     country: "JP"
-  - 
+  -
     ip: "61.122.116.179"
     country: "JP"
     reverse: "bb-ns02.fttx.co.jp"
     provider: "UCOM UCOM Corp."
-  - 
+  -
     ip: "203.94.175.210"
     provider: "UECOMM-AU Uecomm Ltd"
     reverse: "ns2.247.id.au"
     country: "AU"
-  - 
+  -
     ip: "91.193.218.33"
     provider: "UGRASU-AS GOU VPO Yugorskiy State University"
     reverse: "ns.ugrasu.ru"
     country: "RU"
-  - 
+  -
     ip: "66.146.0.1"
     country: "US"
     reverse: "ns1.uia.net"
     provider: "UIA - Ultimate Internet Access, Inc"
-  - 
+  -
     ip: "83.170.65.182"
     provider: "UK2NET-AS UK2 - Ltd"
     reverse: "ns3.ukwebhost.org"
     country: "GB"
-  - 
+  -
     ip: "83.170.69.2"
     country: "GB"
     reverse: "ns2.web-ns.net"
     provider: "UK2NET-AS UK2 - Ltd"
-  - 
+  -
     ip: "83.170.72.34"
     provider: "UK2NET-AS UK2 - Ltd"
     reverse: "ns.rjg-consultants.com"
     country: "GB"
-  - 
+  -
     ip: "156.154.70.1"
     country: "US"
     reverse: "rdns1.ultradns.net"
     provider: "ULTRADNS - NeuStar, Inc."
-  - 
+  -
     ip: "156.154.71.1"
     country: "US"
     reverse: "rdns2.ultradns.net"
     provider: "ULTRADNS - NeuStar, Inc."
-  - 
+  -
     ip: "156.154.70.22"
     provider: "ULTRADNS - NeuStar, Inc."
     reverse: "156.154.70.22"
     country: "US"
-  - 
+  -
     ip: "156.154.71.22"
     provider: "ULTRADNS - NeuStar, Inc."
     reverse: "156.154.71.22"
     country: "US"
-  - 
+  -
     ip: "130.85.1.3"
     country: "US"
     reverse: "umbc3.umbc.edu"
     provider: "UMBC-AS - University of Maryland Baltimore County (UMBC)"
-  - 
+  -
     ip: "130.85.1.5"
     provider: "UMBC-AS - University of Maryland Baltimore County (UMBC)"
     reverse: "umbc5.umbc.edu"
     country: "US"
-  - 
+  -
     ip: "195.93.151.151"
     country: "RU"
     reverse: "ns2.uminet.ru"
     provider: "UMI-NET-AS UMI-net Ltd"
-  - 
+  -
     ip: "141.211.125.15"
     provider: "UMICH-AS-5 - University of Michigan"
     reverse: "twelvemonkeys.mr.itd.umich.edu"
     country: "US"
-  - 
+  -
     ip: "141.211.125.17"
     country: "US"
     reverse: "lifeofbrian.mr.itd.umich.edu"
     provider: "UMICH-AS-5 - University of Michigan"
-  - 
+  -
     ip: "141.211.144.15"
     provider: "UMICH-AS-5 - University of Michigan"
     reverse: "jabberwocky.mr.itd.umich.edu"
     country: "US"
-  - 
+  -
     ip: "141.211.144.17"
     country: "US"
     reverse: "timebandits.mr.itd.umich.edu"
     provider: "UMICH-AS-5 - University of Michigan"
-  - 
+  -
     ip: "91.194.144.252"
     country: "PL"
     reverse: "91.194.144.252"
     provider: "UMWL1-AS Urzad Marszalkowski w Lodzi"
-  - 
+  -
     ip: "62.36.225.150"
     provider: "UNI2-AS France Telecom Espana SA"
     reverse: "dnscache1.orange.es"
     country: "ES"
-  - 
+  -
     ip: "62.37.225.57"
     country: "ES"
     reverse: "dns2.comtenidos.com"
     provider: "UNI2-AS France Telecom Espana SA"
-  - 
+  -
     ip: "62.37.228.20"
     provider: "UNI2-AS France Telecom Espana SA"
     reverse: "m2dnscache.net.uni2.es"
     country: "ES"
-  - 
+  -
     ip: "217.70.3.131"
     provider: "UNI2-AS France Telecom Espana SA"
     reverse: "dns2.cast-info.es"
     country: "ES"
-  - 
+  -
     ip: "141.2.1.1"
     provider: "UNIFFM-NET Johann Wolfgang Goethe-Universitat Frankfurt am Main"
     reverse: "hera.rbi.informatik.uni-frankfurt.de"
     country: "DE"
-  - 
+  -
     ip: "141.2.1.3"
     country: "DE"
     reverse: "hermes.rbi.informatik.uni-frankfurt.de"
     provider: "UNIFFM-NET Johann Wolfgang Goethe-Universitat Frankfurt am Main"
-  - 
+  -
     ip: "217.196.1.5"
     country: "GB"
     reverse: "ns.userve.net"
     provider: "UNITRON-AS Unitron Systems & Development LTD Autonomous System"
-  - 
+  -
     ip: "217.196.1.6"
     provider: "UNITRON-AS Unitron Systems & Development LTD Autonomous System"
     reverse: "ns2.userve.net"
     country: "GB"
-  - 
+  -
     ip: "129.7.1.1"
     provider: "UNIVERSITY-OF-HOUSTON - University of Houston"
     reverse: "walnut.cc.uh.edu"
     country: "US"
-  - 
+  -
     ip: "129.7.1.6"
     country: "US"
     reverse: "fir.cc.uh.edu"
     provider: "UNIVERSITY-OF-HOUSTON - University of Houston"
-  - 
+  -
     ip: "202.29.95.141"
     provider: "UNSPECIFIED UNINET-TH"
     reverse: "202.29.95.141"
     country: "TH"
-  - 
+  -
     ip: "153.2.242.116"
     country: "US"
     reverse: "xavier2.ups.com"
     provider: "UPS - UNITED PARCEL SERVICE"
-  - 
+  -
     ip: "69.67.254.2"
     country: "US"
     reverse: "ns1.usadatanet.com"
     provider: "USADATANET - US Data Net"
-  - 
+  -
     ip: "160.79.6.130"
     country: "US"
     reverse: "ns1.east.us.intellispace.net"
     provider: "USCYBERSITES - US Cybersites, Inc"
-  - 
+  -
     ip: "207.2.120.249"
     country: "US"
     reverse: "dnscache1.rnktel.com"
     provider: "USCYBERSITES - US Cybersites, Inc"
-  - 
+  -
     ip: "212.220.176.254"
     provider: "USI OJSC Rostelecom"
     reverse: "ns.mtex.ru"
     country: "RU"
-  - 
+  -
     ip: "142.77.2.36"
     country: "US"
     reverse: "cache02.ca-dns.net"
     provider: "UUNET - MCI Communications Services, Inc. d/b/a Verizon Business"
-  - 
+  -
     ip: "198.6.1.1"
     country: "US"
     reverse: "cache00.ns.uu.net"
     provider: "UUNET - MCI Communications Services, Inc. d/b/a Verizon Business"
-  - 
+  -
     ip: "198.6.1.2"
     provider: "UUNET - MCI Communications Services, Inc. d/b/a Verizon Business"
     reverse: "cache01.ns.uu.net"
     country: "US"
-  - 
+  -
     ip: "198.6.1.3"
     country: "US"
     reverse: "cache02.ns.uu.net"
     provider: "UUNET - MCI Communications Services, Inc. d/b/a Verizon Business"
-  - 
+  -
     ip: "198.6.1.4"
     provider: "UUNET - MCI Communications Services, Inc. d/b/a Verizon Business"
     reverse: "cache03.ns.uu.net"
     country: "US"
-  - 
+  -
     ip: "198.6.1.5"
     country: "US"
     reverse: "cache04.ns.uu.net"
     provider: "UUNET - MCI Communications Services, Inc. d/b/a Verizon Business"
-  - 
+  -
     ip: "198.6.1.6"
     provider: "UUNET - MCI Communications Services, Inc. d/b/a Verizon Business"
     reverse: "dialcache060.ns.uu.net"
     country: "US"
-  - 
+  -
     ip: "198.6.1.122"
     country: "US"
     reverse: "cache06.ns.uu.net"
     provider: "UUNET - MCI Communications Services, Inc. d/b/a Verizon Business"
-  - 
+  -
     ip: "198.6.1.142"
     provider: "UUNET - MCI Communications Services, Inc. d/b/a Verizon Business"
     reverse: "cache07.ns.uu.net"
     country: "US"
-  - 
+  -
     ip: "198.6.1.146"
     country: "US"
     reverse: "cache08.ns.uu.net"
     provider: "UUNET - MCI Communications Services, Inc. d/b/a Verizon Business"
-  - 
+  -
     ip: "198.6.1.195"
     provider: "UUNET - MCI Communications Services, Inc. d/b/a Verizon Business"
     reverse: "cache05.ns.uu.net"
     country: "US"
-  - 
+  -
     ip: "203.166.97.9"
     provider: "UUNET - MCI Communications Services, Inc. d/b/a Verizon Business"
     reverse: "snscache0.syd.ops.aspac.uu.net"
     country: "US"
-  - 
+  -
     ip: "203.166.97.10"
     country: "US"
     reverse: "snscache1.syd.ops.aspac.uu.net"
     provider: "UUNET - MCI Communications Services, Inc. d/b/a Verizon Business"
-  - 
+  -
     ip: "206.64.118.165"
     country: "US"
     reverse: "sosrv1.por3.maint.ops.us.uu.net"
     provider: "UUNET - MCI Communications Services, Inc. d/b/a Verizon Business"
-  - 
+  -
     ip: "192.76.144.66"
     country: "US"
     reverse: "cache0701.ns.eu.uu.net"
     provider: "UUNET-INT - MCI Communications Services, Inc. d/b/a Verizon Business"
-  - 
+  -
     ip: "142.104.6.1"
     country: "CA"
     reverse: "dns1.uvic.ca"
     provider: "UVIC-AS - University of Victoria"
-  - 
+  -
     ip: "142.104.80.2"
     provider: "UVIC-AS - University of Victoria"
     reverse: "dns2.uvic.ca"
     country: "CA"
-  - 
+  -
     ip: "212.87.3.1"
     provider: "UW-AS University of Warsaw"
     reverse: "alfa.chem.uw.edu.pl"
     country: "PL"
-  - 
+  -
     ip: "130.95.128.2"
     country: "AU"
     reverse: "dns.uwa.edu.au"
     provider: "UWA-AS-AP University of Western Australia"
-  - 
+  -
     ip: "148.233.151.6"
     country: "MX"
     reverse: "customer-148-233-151-6.uninet.net.mx"
     provider: "Uninet S.A. de C.V."
-  - 
+  -
     ip: "148.233.151.8"
     provider: "Uninet S.A. de C.V."
     reverse: "148.233.151.8"
     country: "MX"
-  - 
+  -
     ip: "200.221.11.100"
     country: "BR"
     reverse: "brahms.uol.com.br"
     provider: "Universo Online S.A."
-  - 
+  -
     ip: "198.82.247.34"
     provider: "VA-TECH-AS - Virginia Polytechnic Institute and State Univ."
     reverse: "yardbird.cns.vt.edu"
     country: "US"
-  - 
+  -
     ip: "216.126.204.8"
     provider: "VCS-AS - Virtacore Systems Inc"
     reverse: "ns1.ispnetbilling.com"
     country: "US"
-  - 
+  -
     ip: "163.139.21.197"
     country: "JP"
     reverse: "ns11.vectant.ne.jp"
     provider: "VECTANT VECTANT Ltd."
-  - 
+  -
     ip: "163.139.230.168"
     provider: "VECTANT VECTANT Ltd."
     reverse: "ns10.vectant.ne.jp"
     country: "JP"
-  - 
+  -
     ip: "202.215.242.193"
     country: "JP"
     reverse: "dns2.i2ts.net"
     provider: "VECTANT VECTANT Ltd."
-  - 
+  -
     ip: "210.131.159.24"
     country: "JP"
     reverse: "ns1.em-net.ne.jp"
     provider: "VECTANT VECTANT Ltd."
-  - 
+  -
     ip: "210.131.249.33"
     provider: "VECTANT VECTANT Ltd."
     reverse: "ns1.i2ts.ne.jp"
     country: "JP"
-  - 
+  -
     ip: "210.170.57.225"
     provider: "VECTANT VECTANT Ltd."
     reverse: "ns3.i2ts.ne.jp"
     country: "JP"
-  - 
+  -
     ip: "88.156.96.61"
     provider: "VECTRANET-AS VECTRA S.A."
     reverse: "dns3.vectranet.pl"
     country: "PL"
-  - 
+  -
     ip: "149.154.159.12"
     provider: "VELIANET-AS velia.net Internetdienste GmbH"
     reverse: "de.godau.eu"
     country: "DE"
-  - 
+  -
     ip: "194.145.230.9"
     country: "DE"
     reverse: "dns.w-s-r.de"
     provider: "VERSATEL Versatel Deutschland GmbH"
-  - 
+  -
     ip: "195.202.33.68"
     country: "DE"
     reverse: "muensmain.citykom.de"
     provider: "VERSATEL Versatel Deutschland GmbH"
-  - 
+  -
     ip: "213.30.253.65"
     provider: "VERSATEL Versatel Deutschland GmbH"
     reverse: "mail.inxmail.de"
     country: "DE"
-  - 
+  -
     ip: "213.139.128.59"
     provider: "VERSATEL Versatel Deutschland GmbH"
     reverse: "ns.mainz-kom.net"
     country: "DE"
-  - 
+  -
     ip: "213.139.132.5"
     country: "DE"
     reverse: "dns.innoventec.net"
     provider: "VERSATEL Versatel Deutschland GmbH"
-  - 
+  -
     ip: "212.2.33.33"
     country: "DE"
     reverse: "berthold.skylink.de"
     provider: "VFNM-NET datadirect gmbh"
-  - 
+  -
     ip: "80.94.196.1"
     country: "GB"
     reverse: "ns1.serverdns.net"
     provider: "VIBUS-AS Vibus"
-  - 
+  -
     ip: "80.94.198.1"
     provider: "VIBUS-AS Vibus"
     reverse: "ns2.serverdns.net"
     country: "GB"
-  - 
+  -
     ip: "205.151.222.250"
     provider: "VIDEOTRON - Videotron Telecom Ltee"
     reverse: "dns3.videotron.net"
     country: "CA"
-  - 
+  -
     ip: "205.151.222.251"
     country: "CA"
     reverse: "dns4.videotron.net"
     provider: "VIDEOTRON - Videotron Telecom Ltee"
-  - 
+  -
     ip: "66.133.111.200"
     country: "US"
     reverse: "ns1.consonus.com"
     provider: "VINS-AS-6 - ViaWest"
-  - 
+  -
     ip: "64.254.99.13"
     country: "US"
     reverse: "ns3.virtela.net"
     provider: "VIRTELA-NET-VMABOS1 Virtela Communications"
-  - 
+  -
     ip: "64.254.100.20"
     provider: "VIRTELA-NET-VNYNYC1 Virtela Communications"
     reverse: "vnynyc1-dnsp-1.virtela.net"
     country: "US"
-  - 
+  -
     ip: "206.131.229.9"
     country: "US"
     reverse: "ns1.minerva.net"
     provider: "VIRTUSTREAM-US - Virtustream Inc."
-  - 
+  -
     ip: "209.193.68.2"
     country: "US"
     reverse: "ns2.vcn.com"
     provider: "VISIONARY - Visionary Communications, Inc."
-  - 
+  -
     ip: "209.193.72.2"
     provider: "VISIONARY - Visionary Communications, Inc."
     reverse: "ns1.vcn.com"
     country: "US"
-  - 
+  -
     ip: "145.253.2.6"
     provider: "VODANET Vodafone GmbH"
     reverse: "145.253.2.6"
     country: "DE"
-  - 
+  -
     ip: "145.253.2.7"
     country: "DE"
     reverse: "145.253.2.7"
     provider: "VODANET Vodafone GmbH"
-  - 
+  -
     ip: "193.189.114.254"
     country: "DE"
     reverse: "ip254.net02.communicode.net"
     provider: "VODANET Vodafone GmbH"
-  - 
+  -
     ip: "195.50.157.2"
     country: "DE"
     reverse: "ns01.azeti.net"
     provider: "VODANET Vodafone GmbH"
-  - 
+  -
     ip: "195.242.173.2"
     provider: "VODANET Vodafone GmbH"
     reverse: "gws-01.tdm.de"
     country: "DE"
-  - 
+  -
     ip: "213.23.95.2"
     provider: "VODANET Vodafone GmbH"
     reverse: "www.wwag.com"
     country: "DE"
-  - 
+  -
     ip: "89.249.224.1"
     provider: "VOL-AS Vist on-line AS"
     reverse: "relay-1.vistcom.ru"
     country: "RU"
-  - 
+  -
     ip: "193.22.119.195"
     country: "EU"
     reverse: "srv-es-01.voztelecom.net"
     provider: "VOZTELECOM VozTelecom Network"
-  - 
+  -
     ip: "193.219.125.2"
     country: "RU"
     reverse: "ns1.vss-63.ru"
     provider: "VSS-SAMARA-AS OOO _VolgaSvyazService_"
-  - 
+  -
     ip: "81.23.73.90"
     country: "CH"
     reverse: "ns2.cybernetwork.ch"
     provider: "VTX-NETWORK VTX Services SA"
-  - 
+  -
     ip: "81.23.73.120"
     provider: "VTX-NETWORK VTX Services SA"
     reverse: "ns1.cybernetwork.ch"
     country: "CH"
-  - 
+  -
     ip: "212.40.5.50"
     country: "CH"
     reverse: "ns2.datacomm.ch"
     provider: "VTX-NETWORK VTX Services SA"
-  - 
+  -
     ip: "212.147.10.10"
     country: "CH"
     reverse: "rs01.vtx.ch"
     provider: "VTX-NETWORK VTX Services SA"
-  - 
+  -
     ip: "199.5.47.164"
     provider: "VWNA-AS - Volkswagen of America, Inc."
     reverse: "ns1.vw.com"
     country: "US"
-  - 
+  -
     ip: "206.124.64.1"
     provider: "VZN-VOL1 - Verizon Online LLC"
     reverse: "bigguy.gte.net"
     country: "US"
-  - 
+  -
     ip: "206.124.64.253"
     country: "US"
     reverse: "oingo.gte.net"
     provider: "VZN-VOL1 - Verizon Online LLC"
-  - 
+  -
     ip: "206.124.65.253"
     provider: "VZN-VOL1 - Verizon Online LLC"
     reverse: "boingo.gte.net"
     country: "US"
-  - 
+  -
     ip: "68.179.203.94"
     country: "US"
     reverse: "ns2.wa-k20.net"
     provider: "WA-K20 - Washington State K-20 Telecommunications Network"
-  - 
+  -
     ip: "216.186.27.15"
     provider: "WA-K20 - Washington State K-20 Telecommunications Network"
     reverse: "ns1.ohsd.net"
     country: "US"
-  - 
+  -
     ip: "93.187.209.34"
     country: "CH"
     reverse: "ns2.widag.net"
     provider: "WAGNER Wagner AG Informatik Dienstleistungen"
-  - 
+  -
     ip: "195.214.240.136"
     country: "DE"
     reverse: "ns2.waycom.net"
     provider: "WAYCOM-AS Waycom International SARL"
-  - 
+  -
     ip: "111.67.16.202"
     provider: "WEB24-VIC-AU Web24 Virtual & Dedicated hosting service provider, Melb, Australia"
     reverse: "111.67.16.202"
     country: "AU"
-  - 
+  -
     ip: "193.108.34.4"
     country: "PL"
     reverse: "dns2.webinn.pl"
     provider: "WEBINN Web Inn SA"
-  - 
+  -
     ip: "89.233.43.71"
     provider: "WEBPARTNER WEBPARTNER A/S is a Danish Internet Service Provider"
     reverse: "ns1.censurfridns.dk"
     country: "DK"
-  - 
+  -
     ip: "204.244.3.129"
     provider: "WESTEL-1 - WesTel Telecommunications"
     reverse: "ns2.navigata.net"
     country: "CA"
-  - 
+  -
     ip: "204.244.3.130"
     country: "CA"
     reverse: "ns1.navigata.net"
     provider: "WESTEL-1 - WesTel Telecommunications"
-  - 
+  -
     ip: "91.198.89.11"
     country: "PL"
     reverse: "ns2.wieszowanet.pl"
     provider: "WIESZOWANET-AS _Maniera Service_ - Biuro Uslug Komputerowo-Internetowych"
-  - 
+  -
     ip: "91.198.89.34"
     provider: "WIESZOWANET-AS _Maniera Service_ - Biuro Uslug Komputerowo-Internetowych"
     reverse: "ns.wieszowanet.pl"
     country: "PL"
-  - 
+  -
     ip: "82.138.232.96"
     provider: "WILDCARD-AS Wildcard UK Ltd"
     reverse: "ifl1.internetf.co.uk"
     country: "GB"
-  - 
+  -
     ip: "207.91.5.32"
     provider: "WINDSTREAM - Windstream Communications Inc"
     reverse: "nsvip06.windstream.net"
     country: "US"
-  - 
+  -
     ip: "208.38.65.35"
     provider: "WINDSTREAM - Windstream Communications Inc"
     reverse: "dnscache2.izoom.net"
     country: "US"
-  - 
+  -
     ip: "208.38.65.37"
     country: "US"
     reverse: "dnscache1.izoom.net"
     provider: "WINDSTREAM - Windstream Communications Inc"
-  - 
+  -
     ip: "216.199.54.9"
     country: "US"
     reverse: "nsftl.fdn.com"
     provider: "WINDSTREAM - Windstream Communications Inc"
-  - 
+  -
     ip: "217.19.176.2"
     provider: "WITCOM-AS WITCOM Wiesbadener Informations- und Telekommunikations GmbH"
     reverse: "dns-1.witcom.de"
     country: "DE"
-  - 
+  -
     ip: "91.216.105.75"
     provider: "WITOPIA-AS1 - WiTopia, Inc."
     reverse: "cache03.ns.witopia.net"
     country: "US"
-  - 
+  -
     ip: "217.67.96.3"
     provider: "WMGROUP-AS WM-Group"
     reverse: "ncc1701.wmo.de"
     country: "DE"
-  - 
+  -
     ip: "129.219.13.81"
     provider: "WN-AZ-AS - Arizona Tri University Network"
     reverse: "asudns2.asu.edu"
     country: "US"
-  - 
+  -
     ip: "129.219.17.5"
     country: "US"
     reverse: "asudns1.inre.asu.edu"
     provider: "WN-AZ-AS - Arizona Tri University Network"
-  - 
+  -
     ip: "129.219.17.200"
     provider: "WN-AZ-AS - Arizona Tri University Network"
     reverse: "asudns3.asu.edu"
     country: "US"
-  - 
+  -
     ip: "64.140.243.112"
     provider: "WORLDPATH-AS - WorldPath Internet Services"
     reverse: "ns2.lanlink.net"
     country: "US"
-  - 
+  -
     ip: "213.209.121.30"
     country: "DE"
     reverse: "ns2.gid24.de"
     provider: "WTNET-AS wilhelm.tel GmbH Norderstedt"
-  - 
+  -
     ip: "213.209.122.11"
     provider: "WTNET-AS wilhelm.tel GmbH Norderstedt"
     reverse: "ns1.gid24.de"
     country: "DE"
-  - 
+  -
     ip: "66.216.18.222"
     provider: "WVFIBER-1 - WV FIBER"
     reverse: "66.216.18.222"
     country: "US"
-  - 
+  -
     ip: "64.0.55.201"
     country: "US"
     reverse: "w201.z064000055.alb-ny.dsl.cnc.net"
     provider: "XO-AS15 - XO Communications"
-  - 
+  -
     ip: "67.90.152.122"
     country: "US"
     reverse: "ip67-90-152-122.z152-90-67.customer.algx.net"
     provider: "XO-AS15 - XO Communications"
-  - 
+  -
     ip: "67.107.71.186"
     provider: "XO-AS15 - XO Communications"
     reverse: "67.107.71.186.ptr.us.xo.net"
     country: "US"
-  - 
+  -
     ip: "207.238.196.67"
     provider: "XO-AS15 - XO Communications"
     reverse: "ns1.iseeusecurity.com"
     country: "US"
-  - 
+  -
     ip: "77.88.8.88"
     country: "RU"
     reverse: "safe.dns.yandex.ru"
     provider: "YANDEX Yandex LLC"
-  - 
+  -
     ip: "217.148.54.3"
     country: "RU"
     reverse: "ns3.ycc.ru"
     provider: "YCC-AS +-------------------------------------------------------"
-  - 
+  -
     ip: "62.151.2.8"
     provider: "YIF-AS France Telecom Espana S.A"
     reverse: "dns.ya.com"
     country: "ES"
-  - 
+  -
     ip: "195.58.64.62"
     provider: "YOUR-COMMS-UK-AS Thus Group Plc."
     reverse: "195.58.64.62"
     country: "GB"
-  - 
+  -
     ip: "193.7.168.1"
     provider: "ZA-AS za-internet GmbH"
     reverse: "ns5.za-internet.net"
     country: "DE"
-  - 
+  -
     ip: "193.7.169.9"
     country: "DE"
     reverse: "ns3.zollern-alb.de"
     provider: "ZA-AS za-internet GmbH"
-  - 
+  -
     ip: "194.150.251.2"
     country: "PL"
     reverse: "dns.zdnet.com.pl"
     provider: "ZD-NET ZDNet S.C. Marcin Miller, Piotr Woszczak"
-  - 
+  -
     ip: "195.137.162.149"
     provider: "ZEORK-AS PGE Dystrybucja S.A."
     reverse: "firebird.meskonet.pl"
     country: "PL"
-  - 
+  -
     ip: "212.109.155.129"
     provider: "ZIELMAN-COM-AS AS dedicated to commercial users"
     reverse: "no.pl"
     country: "PL"
-  - 
+  -
     ip: "82.200.124.12"
     country: "RU"
     reverse: "82.200.124.12"


### PR DESCRIPTION
These removed DNS servers consistently returned bad results, either because they're for parked domains only or because they're deprecated.
