### PR TITLE
Only require argparse on <2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ THE SOFTWARE.
 from setuptools import setup, find_packages
 import sys, os
 
-version = '1.0.3'
+version = '1.0.4'
 install_requires = ['PyYAML==3.10', 'dnspython==1.11.1', 'requests==2.0.0']
 
 if sys.version[:2] <= [2, 6]:


### PR DESCRIPTION
(This is especially bad because argparse on PyPI is externally hosted, so it won't work on newer pips which don't install external stuff by default, even on 2.7 where it's not even needed.)
