### PR TITLE
remove inaccessible IIJ JP servers

### DIFF
--- a/resolver-list.yml
+++ b/resolver-list.yml
@@ -3797,16 +3797,6 @@
     reverse: "ns4.iij.ad.jp"
     country: "JP"
   -
-    ip: "210.130.0.1"
-    provider: "IIJ Internet Initiative Japan Inc."
-    reverse: "ns01.iij4u.or.jp"
-    country: "JP"
-  -
-    ip: "210.130.1.1"
-    country: "JP"
-    reverse: "ns11.iij4u.or.jp"
-    provider: "IIJ Internet Initiative Japan Inc."
-  -
     ip: "195.178.195.1"
     provider: "IIP-NET-AS5429 _UMOS CENTER_ LLC"
     reverse: "195.178.195.1"


### PR DESCRIPTION
These servers systematically return an IIJ IP which states that external access is forbidden since 2013/12/2
